### PR TITLE
PowerUp Invoke-AllChecks Fix

### DIFF
--- a/lib/modules/powershell/privesc/powerup/allchecks.py
+++ b/lib/modules/powershell/privesc/powerup/allchecks.py
@@ -70,13 +70,11 @@ class Module(object):
 
         moduleCode = f.read()
         f.close()
-        moduleCode = bytes(moduleCode)
         # # get just the code needed for the specified function
         # script = helpers.generate_dynamic_powershell_script(moduleCode, moduleName)
         script = moduleCode
 
         scriptEnd = ';' + moduleName + " "
-        print('allchecks.py: line 79')
         for option,values in self.options.items():
             if option.lower() != "agent":
                 if values['Value'] and values['Value'] != '':
@@ -87,10 +85,8 @@ class Module(object):
                         scriptEnd += " -" + str(option) + " " + str(values['Value']) 
 
         scriptEnd += ' | Out-String | %{$_ + \"`n\"};"`n'+str(moduleName)+' completed!"'
-        print('allchecks.py: line 90')
         if obfuscate:
             print('obfuscating script: allchecks.py')
             scriptEnd = helpers.obfuscate(self.mainMenu.installPath, psScript=scriptEnd, obfuscationCommand=obfuscationCommand)
         script += scriptEnd
-        print('allchecks.py: line 95')
         return script


### PR DESCRIPTION
Can't seem to understand why it wanted the bytes and not the string payload.
Tested on the latest Windows 10 build, works fine