### PR TITLE
Python 3.8 compatibility for staging encryption routine

### DIFF
--- a/data/agent/stagers/common/aes.py
+++ b/data/agent/stagers/common/aes.py
@@ -325,7 +325,7 @@ def aes_encrypt_then_hmac(key, data):
        data = bytes(data, 'UTF-8')
 
     data = aes_encrypt(key, data)
-    mac = hmac.new(key, data, hashlib.sha256).digest()
+    mac = hmac.new(key, data, digestmod=hashlib.sha256).digest()
     return data + mac[0:10]
 
 
@@ -349,10 +349,10 @@ def verify_hmac(key, data):
     if len(data) > 20:
         mac = data[-10:]
         data = data[:-10]
-        expected = hmac.new(key, data, hashlib.sha256).digest()[0:10]
+        expected = hmac.new(key, data, digestmod=hashlib.sha256).digest()[0:10]
         # Double HMAC to prevent timing attacks. hmac.compare_digest() is
         # preferable, but only available since Python 2.7.7.
-        return hmac.new(key, expected).digest() == hmac.new(key, mac).digest()
+        return hmac.new(key, expected, digestmod=hashlib.sha256).digest() == hmac.new(key, mac, digestmod=hashlib.sha256).digest()
     else:
         return False
 

--- a/lib/common/encryption.py
+++ b/lib/common/encryption.py
@@ -160,7 +160,7 @@ def aes_encrypt_then_hmac(key, data):
        data = bytes(data, 'UTF-8')
 
     data = aes_encrypt(key, data)
-    mac = hmac.new(key, data, hashlib.sha256).digest()
+    mac = hmac.new(key, data, digestmod=hashlib.sha256).digest()
     return data + mac[0:10]
 
 
@@ -187,10 +187,10 @@ def verify_hmac(key, data):
     if len(data) > 20:
         mac = data[-10:]
         data = data[:-10]
-        expected = hmac.new(key, data, hashlib.sha256).digest()[0:10]
+        expected = hmac.new(key, data, digestmod=hashlib.sha256).digest()[0:10]
         # Double HMAC to prevent timing attacks. hmac.compare_digest() is
         # preferable, but only available since Python 2.7.7.
-        return hmac.new(key, expected).digest() == hmac.new(key, mac).digest()
+        return hmac.new(key, expected, digestmod=hashlib.sha256).digest() == hmac.new(key, mac, digestmod=hashlib.sha256).digest()
     else:
         return False
 

--- a/lib/modules/python/collection/osx/keychaindump_chainbreaker.py
+++ b/lib/modules/python/collection/osx/keychaindump_chainbreaker.py
@@ -1230,7 +1230,7 @@ def pbkdf2(password, salt, itercount, keylen, hashfn=sha):
     if keylen % BLOCKLEN != 0:
         l += 1
 
-    h = hmac.new(password, None, hashfn)
+    h = hmac.new(password, None, digestmod=hashfn)
 
     T = ""
     for i in range(1, l + 1):


### PR DESCRIPTION
As of Python 3.8, the explicit keyword `digestmod=` in the hmac.new() function is required. Without this, staging process will throw out `HMAC Verification failed` error. 

Tested with Python 3.8.1 and 2.7.17