### PR TITLE
Fixed stager for OSX and appbundle creation

### DIFF
--- a/lib/common/stagers.py
+++ b/lib/common/stagers.py
@@ -274,10 +274,10 @@ class Stagers(object):
 
         if Arch == 'x64':
 
-            f = open(self.mainMenu.installPath + "/data/misc/apptemplateResources/x64/launcher.app/Contents/MacOS/launcher")
+            f = open(self.mainMenu.installPath + "/data/misc/apptemplateResources/x64/launcher.app/Contents/MacOS/launcher", "rb")
             directory = self.mainMenu.installPath + "/data/misc/apptemplateResources/x64/launcher.app/"
         else:
-            f = open(self.mainMenu.installPath + "/data/misc/apptemplateResources/x86/launcher.app/Contents/MacOS/launcher")
+            f = open(self.mainMenu.installPath + "/data/misc/apptemplateResources/x86/launcher.app/Contents/MacOS/launcher", "rb")
             directory = self.mainMenu.installPath + "/data/misc/apptemplateResources/x86/launcher.app/"
 
         macho = macholib.MachO.MachO(f.name)
@@ -292,10 +292,10 @@ class Stagers(object):
             count = 0
             if int(cmd[count].cmd) == macholib.MachO.LC_SEGMENT_64 or int(cmd[count].cmd) == macholib.MachO.LC_SEGMENT:
                 count += 1
-                if cmd[count].segname.strip('\x00') == '__TEXT' and cmd[count].nsects > 0:
+                if cmd[count].segname.strip(b'\x00') == b'__TEXT' and cmd[count].nsects > 0:
                     count += 1
                     for section in cmd[count]:
-                        if section.sectname.strip('\x00') == '__cstring':
+                        if section.sectname.strip(b'\x00') == b'__cstring':
                             offset = int(section.offset)
                             placeHolderSz = int(section.size) - 52
 
@@ -304,7 +304,7 @@ class Stagers(object):
 
         if placeHolderSz and offset:
 
-            launcher = launcherCode + "\x00" * (placeHolderSz - len(launcherCode))
+            launcher = launcherCode.encode('utf8') + b'\x00' * (placeHolderSz - len(launcherCode))
             patchedBinary = template[:offset]+launcher+template[(offset+len(launcher)):]
             if AppName == "":
                 AppName = "launcher"

--- a/lib/stagers/osx/application.py
+++ b/lib/stagers/osx/application.py
@@ -97,6 +97,6 @@ class Stager(object):
 
         else:
             disarm = False
-            launcher = launcher.strip('echo').strip(' | /usr/bin/python &').strip("\"")
+            launcher = launcher.strip('echo').strip(' | /usr/bin/python3 &').strip("\"")
             ApplicationZip = self.mainMenu.stagers.generate_appbundle(launcherCode=launcher,Arch=arch,icon=icnsPath,AppName=AppName, disarm=disarm)
             return ApplicationZip


### PR DESCRIPTION
I found 3 bugs during the creation of a stager for OSX running Empire with Python 3.

**Bug 1**
Using Python 3, during the creation of a OSX stager, Empire throws an exception related to a str object passed instead of a byte-like:
```
(Empire) > usestager osx/application
(Empire: stager/osx/application) > set Listener http
(Empire: stager/osx/application) > generate
[!] Exception: a bytes-like object is required, not ‘str'
```
That is caused by the fact the object `cmd[count].segname` is of type byte and the same type is required by `strip` for its argument. 

**Bug 2**
The second bug is related on how Empire opens the templates in `/data/misc/apptemplateResources`. By default Python 3 uses utf8 for encoding and when the template is parsed it throws an exception because it can't decode a byte in utf-8:
```
(Empire) > usestager osx/application
(Empire: stager/osx/application) > set Listener http
(Empire: stager/osx/application) > generate
[!] Exception: 'utf-8' codec can't decode byte 0xcf in position 0: invalid continuation byte
```
Specifying that the file has to be opened as a binary fixes the bug.

**Bug 3**
Since the python path [changed](https://github.com/BC-SECURITY/Empire/blob/998b490981cb30e8b845471293ab67a37dd3d572/lib/listeners/http.py#L519) `strip` in [application.py](https://github.com/BC-SECURITY/Empire/blob/998b490981cb30e8b845471293ab67a37dd3d572/lib/stagers/osx/application.py#L100) doesn't remove the string ` | /usr/bin/python &` and the resulting python command, injected in the appbundle template, is broken.