### PR TITLE
fix rest login error 500 for starkiller

### DIFF
--- a/lib/common/users.py
+++ b/lib/common/users.py
@@ -108,7 +108,7 @@ class Users():
         try:
             self.lock.acquire()
             cur = conn.cursor()
-            user = cur.execute("SELECT password from users WHERE username = ? AND enabled = true LIMIT 1", (user_name,)).fetchone()
+            user = cur.execute("SELECT password from users WHERE username = ? AND enabled = 1 LIMIT 1", (user_name,)).fetchone()
             
             if user == None:
                 return None


### PR DESCRIPTION
try to login via the rest api always got me the following error:

HTTP/1.0 500
Content-Type: application/json
Content-Length: 54
Access-Control-Allow-Origin: *
Server: Werkzeug/1.0.0 Python/3.6.9
Date: Mon, 09 Mar 2020 15:48:02 GMT

{"error":"OperationalError('no such column: true',)"}

---------------------------------------------------------

enabled must be check for '1' not 'true' to fix this issue and allow starkiller to work with the latest version of empire.