### PR TITLE
Fix non-ascii filename download bug

### DIFF
--- a/lib/common/packets.py
+++ b/lib/common/packets.py
@@ -165,7 +165,7 @@ def build_task_packet(taskName, data, resultID):
     totalPacket = struct.pack('=H', 1)
     packetNum = struct.pack('=H', 1)
     resultID = struct.pack('=H', resultID)
-    length = struct.pack('=L', len(data))
+    length = struct.pack('=L', len(data.encode("UTF-8")))
     return taskType + totalPacket + packetNum + resultID + length + data.encode("UTF-8")
 
 def parse_result_packet(packet, offset=0):


### PR DESCRIPTION
fix non-ascii filename downloading error.
When download files with non-ascii filename,the 'length' part in the packet is the length of string of the filename,but not bytes of encoded filename,so throw an index-out-of-bounts error