### PR TITLE
Fix exception thrown in module persistence/powerbreach/resolver

### DIFF
--- a/lib/modules/powershell/persistence/powerbreach/resolver.py
+++ b/lib/modules/powershell/persistence/powerbreach/resolver.py
@@ -150,7 +150,6 @@ Invoke-ResolverBackdoor"""
                 return ""
             else:
                 script = script.replace("REPLACE_LAUNCHER", stagerCode)
-                script = script.encode('ascii', 'ignore')
         
         for option,values in self.options.items():
             if option.lower() != "agent" and option.lower() != "listener" and option.lower() != "outfile":


### PR DESCRIPTION
When I execute module "persistence/powerbreach/resolver",
got `[!] Exception: can't concat str to bytes`.

Because `script = script.encode('ascii', 'ignore')` make script be converted to bytes.
So I removed this line to make it works.
