### PR TITLE
[BUG] Align Invoke-Kerberoast JtR format with magnumripper/JohnTheRipper#2026

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -638,7 +638,7 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
 
                 if($Hash) {
                     if ($OutputFormat -match 'John') {
-                        $HashFormat = "`$krb5tgs`$$($Ticket.ServicePrincipalName):$Hash"
+                        $HashFormat = "$($SamAccountName):`$krb5tgs`$$($Etype)`$$Hash"
                     }
                     else {
                         if ($DistinguishedName -ne 'UNKNOWN') {

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -2739,7 +2739,7 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
 
                 if($Hash) {
                     if ($OutputFormat -match 'John') {
-                        $HashFormat = "`$krb5tgs`$$($Ticket.ServicePrincipalName):$Hash"
+                        $HashFormat = "$($SamAccountName):`$krb5tgs`$$($Etype)`$$Hash"
                     }
                     else {
                         if ($DistinguishedName -ne 'UNKNOWN') {


### PR DESCRIPTION
Hello.

I was just using the `Invoke-Kerberoast` function and have noticed that the format is not correct for JtR. There are two issues, first it does not detect it as the correct format and instead tries to crack it as using a different algorithm (known issue, PowerShellMafia/PowerSploit#310), second when the SPN contains a `:` (such as a port number) it will cause issues with the JtR parser as that delimits the end of the user name. 

It appears the issue is that JtR updated the input format a little in magnumripper/JohnTheRipper#2026 so this PR brings the output format of both `Invoke-Kerberpost.ps1` and `powerview.ps1` into alignment with that.

From my tests, it is working fine for:
```
John the Ripper 1.9.0-jumbo-1 OMP [linux-gnu 64-bit x86_64 AVX2 AC]
Copyright (c) 1996-2019 by Solar Designer and others
```

Although it will probably break backwards compatibility for JtR's from before 2016 :wink: