### PR TITLE
Fixed CLI stager incorrectly shutting down

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -284,11 +284,9 @@ class MainMenu(cmd.Cmd):
                     except Exception as e:
                         print(e)
                         print(helpers.color("\n[!] No current stager with name '%s'\n" % (stagerName)))
-            
-            # shutdown the database connection object
-            if self.conn:
-                self.conn.close()
-            
+
+            # Gracefully shutdown after launcher generation
+            self.shutdown()
             sys.exit()
     
     


### PR DESCRIPTION
Fixed an issue where CLI would ungracefully exit and leave users unable to exit or use Empire.