### PR TITLE
Fixed #454 can't change listerner values bug

### DIFF
--- a/lib/common/listeners.py
+++ b/lib/common/listeners.py
@@ -20,6 +20,7 @@ from builtins import str
 from lib.database.base import Session
 from lib.database import models
 from sqlalchemy import or_, and_
+from sqlalchemy.orm.attributes import flag_modified
 from pydispatch import dispatcher
 
 from . import helpers
@@ -484,7 +485,7 @@ class Listeners(object):
         listener.enabled = False
 
         self.shutdown_listener(listener_name)
-        Session.commit()
+        Session().commit()
 
         # dispatch this event
         message = "[*] Listener {} killed".format(listener_name)
@@ -564,4 +565,5 @@ class Listeners(object):
             print(helpers.color("[!] Listener %s does not have the option %s" % (listener_name, option_name)))
             return
         listener.options[option_name]['Value'] = option_value
+        flag_modified(listener,'options')
         Session().commit()


### PR DESCRIPTION
As mentioned (see #454) this fixes the bug in sqlalchemy usage that prevented editing an existing listener.

Now it is working as intended:
![empire_listeners_change](https://user-images.githubusercontent.com/80632266/117792692-84fc8400-b219-11eb-8184-7adc150ab21a.png)
