### PR TITLE
Add extended rights for certificate template

### DIFF
--- a/empire/server/data/module_source/situational_awareness/network/powerview.ps1
+++ b/empire/server/data/module_source/situational_awareness/network/powerview.ps1
@@ -8565,7 +8565,7 @@ for connection to the target domain.
 
 .PARAMETER Rights
 
-Rights to add for the principal, 'All', 'ResetPassword', 'WriteMembers', 'DCSync'.
+Rights to add for the principal, 'All', 'ResetPassword', 'WriteMembers', 'DCSync', 'Enroll'.
 Defaults to 'All'.
 
 .PARAMETER RightsGUID
@@ -8712,7 +8712,7 @@ https://social.technet.microsoft.com/Forums/windowsserver/en-US/df3bfd33-c070-4a
         [Management.Automation.CredentialAttribute()]
         $Credential = [Management.Automation.PSCredential]::Empty,
 
-        [ValidateSet('All', 'ResetPassword', 'WriteMembers', 'DCSync')]
+        [ValidateSet('All', 'ResetPassword', 'WriteMembers', 'DCSync', 'Enroll')]
         [String]
         $Rights = 'All',
 
@@ -8776,6 +8776,8 @@ https://social.technet.microsoft.com/Forums/windowsserver/en-US/df3bfd33-c070-4a
                     # 'DS-Replication-Get-Changes-In-Filtered-Set' = 89e95b76-444d-4c62-991a-0facbeda640c
                     #   when applied to a domain's ACL, allows for the use of DCSync
                     'DCSync' { '1131f6aa-9c07-11d1-f79f-00c04fc2dcd2', '1131f6ad-9c07-11d1-f79f-00c04fc2dcd2', '89e95b76-444d-4c62-991a-0facbeda640c'}
+                    # allows for certificate enrollment
+                    'Enroll' { '0e10c968-78fb-11d2-90d4-00c04f79dc55' }
                 }
             }
 
@@ -8890,7 +8892,7 @@ for connection to the target domain.
 
 .PARAMETER Rights
 
-Rights to add for the principal, 'All', 'ResetPassword', 'WriteMembers', 'DCSync'.
+Rights to add for the principal, 'All', 'ResetPassword', 'WriteMembers', 'DCSync', 'Enroll'.
 Defaults to 'All'.
 
 .PARAMETER RightsGUID
@@ -8993,7 +8995,7 @@ https://social.technet.microsoft.com/Forums/windowsserver/en-US/df3bfd33-c070-4a
         [Management.Automation.CredentialAttribute()]
         $Credential = [Management.Automation.PSCredential]::Empty,
 
-        [ValidateSet('All', 'ResetPassword', 'WriteMembers', 'DCSync')]
+        [ValidateSet('All', 'ResetPassword', 'WriteMembers', 'DCSync', 'Enroll')]
         [String]
         $Rights = 'All',
 
@@ -9057,6 +9059,8 @@ https://social.technet.microsoft.com/Forums/windowsserver/en-US/df3bfd33-c070-4a
                     # 'DS-Replication-Get-Changes-In-Filtered-Set' = 89e95b76-444d-4c62-991a-0facbeda640c
                     #   when applied to a domain's ACL, allows for the use of DCSync
                     'DCSync' { '1131f6aa-9c07-11d1-f79f-00c04fc2dcd2', '1131f6ad-9c07-11d1-f79f-00c04fc2dcd2', '89e95b76-444d-4c62-991a-0facbeda640c'}
+                    # allows for certificate enrollment
+                    'Enroll' { '0e10c968-78fb-11d2-90d4-00c04f79dc55' }
                 }
             }
 


### PR DESCRIPTION
Hi.

I investigated ESC4 senario in ["Certified Pre-Owned: Abusing Active Directory Certificate Services"](https://posts.specterops.io/certified-pre-owned-d95910965cd2).
To examine the method more conveniently on penetration testing, we added the GUID of Enroll to PowerView's `Add-DomainObjectAcl` and `Remove-DomainObjectAcl` functions as a `-Rights` option.

My investigation is available at the following url:

https://github.com/daem0nc0re/Abusing_Weak_ACL_on_Certificate_Templates