### PR TITLE
Test Account Generated using Insecure RNG

### DIFF
--- a/empire/server/server.py
+++ b/empire/server/server.py
@@ -2287,8 +2287,9 @@ def run(args):
 
     def server_startup_validator():
         print(helpers.color('[*] Testing APIs'))
-        username = 'test-' + ''.join(random.choice(string.ascii_lowercase) for i in range(4))
-        password = ''.join(random.choice(string.ascii_lowercase) for i in range(10))
+        rng = random.SystemRandom()
+        username = 'test-' + ''.join(rng.choice(string.ascii_lowercase) for i in range(4))
+        password = ''.join(rng.choice(string.ascii_lowercase) for i in range(10))
         main.users.add_new_user(username, password)
         response = requests.post(url=f'https://{args.restip}:{args.restport}/api/admin/login',
                                  json={'username': username, 'password': password},


### PR DESCRIPTION
Empire creates a default test account with a password generated using an insecure random number generator (Python's default [`random`](https://docs.python.org/3/library/random.html) based on Mersenne Twister), which as the documentation also points out should never be used in a security context. The RNG's state can be leaked through a variety of other uses through out the application. Due to the leaked state an unauthenticated attacker can potentially recover the RNG's state and then recovery test account's password since it was generated from the same RNG instance.

The user in question is cleaned up, so exploitability is very limited, however best to be safe.

This patch switches the password generation to [`random.SystemRandom`](https://docs.python.org/3/library/random.html#random.SystemRandom) which has API compatibility with `random` but uses a cryptographically secure RNG. In the future only [`random.SystemRandom`](https://docs.python.org/3/library/random.html#random.SystemRandom) or [`secrets`](https://docs.python.org/3/library/secrets.html#module-secrets) should be used to generate credentials, api tokens, etc. anything used in a security-context.

### Additional Resources

* https://research.nccgroup.com/2021/10/18/cracking-random-number-generators-using-machine-learning-part-2-mersenne-twister/
* https://github.com/altf4/untwister

