### PR TITLE
Send shell command to PS1 agent

### DIFF
--- a/empire/client/src/menus/InteractMenu.py
+++ b/empire/client/src/menus/InteractMenu.py
@@ -104,7 +104,7 @@ class InteractMenu(Menu):
 
         Usage: shell <shell_cmd>
         """
-        response = state.agent_shell(self.session_id, shell_cmd)
+        response = state.agent_shell(self.session_id, 'shell ' + shell_cmd)
         print(print_util.color('[*] Tasked ' + self.session_id + ' to run Task ' + str(response['taskID'])))
 
     @command


### PR DESCRIPTION
Powershell agent was designed to act differently between "shell whoami" and "whoami". Using shell is the only way to bypass aliases like whoami.
The new client/server design broke that. Without that we can't request this kind of command "whoami /groups". Adding 'shell' in front of the command in the InteractMenu give us the possibility back.

My solution is not very clever but I don't totally understand your CLI design for the moment.