### PR TITLE
Fixed passing custom headers to powershell stager

### DIFF
--- a/empire/server/listeners/http.py
+++ b/empire/server/listeners/http.py
@@ -633,7 +633,7 @@ class Listener(object):
                     value = key.split(":")
                     if 'cookie' in value[0].lower() and value[1]:
                         continue
-                    remove += value
+                    remove.append(key)
                 headers = ','.join(remove)
                 # headers = ','.join(customHeaders)
                 stager = stager.replace("$customHeaders = \"\";", "$customHeaders = \"" + headers + "\";")
@@ -650,7 +650,6 @@ class Listener(object):
             stager = stager.replace('REPLACE_STAGING_KEY', stagingKey)
             stager = stager.replace('index.jsp', stage1)
             stager = stager.replace('index.php', stage2)
-
 
             randomizedStager = ''
             # forces inputs into a bytestring to ensure 2/3 compatibility


### PR DESCRIPTION
I had the same issues as in https://github.com/BC-SECURITY/Empire/issues/230 but have a suggestion for a fix that does not break the ability to add multiple custom headers. 

When iterating over `customHeaders` (line 632), it seems that all headers apart from the `cookie` header(s) should be passed to the stager. I think it's wrong to only add header values and not the keys to the filtered list, which previously was the case and was the cause why the filtered list didn't  work. By appending the key (which in reality is `headerkey: headervalue`) to the `remove` list (which is the filtered list) and passing this list joined by `,` to the stager, the stager code (e.g. `empire/server/data/agent/stagers/http.ps1`) correctly picks up the custom headers, splits them by `,` and treats the entries in that list as header keys and header values when splitting them by `:`:

```
    if ($customHeaders -ne "") {
        $headers = $customHeaders -split ',';
        $headers | ForEach-Object {
            $headerKey = $_.split(':')[0];
            $headerValue = $_.split(':')[1];
	    #If host header defined, assume domain fronting is in use and add a call to the base URL first
	    #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
	    if ($headerKey -eq "host"){
                try{$ig=$WC.DownloadData($s)}catch{}};
            $wc.Headers.Add($headerKey, $headerValue);
        }
    }
```

The following `DefaultProfiles` work for http listeners with the modified code:
```
set DefaultProfile "/admin/get.php,/news.php,/login/process.php|Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko|host:example.com"
set DefaultProfile "/admin/get.php,/news.php,/login/process.php|Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko|host:example.com|foo:bar"
```