### PR TITLE
Exit when output stream closed

### DIFF
--- a/empire/server/plugins/csharpserver.plugin
+++ b/empire/server/plugins/csharpserver.plugin
@@ -132,7 +132,11 @@ class Plugin(Plugin):
 
     def thread_csharp_responses(self):
         while True:
-            output = self.csharpserver_proc.stdout.readline().rstrip()
+            output = self.csharpserver_proc.stdout.readline()
+            if not output:
+                print(helpers.color("[!] csharpserver output stream closed"))
+                return
+            output = output.rstrip()
             if output:
                 print(helpers.color("[*] " + output.decode("UTF-8")))
 


### PR DESCRIPTION
Prevents infinite loop when output stream from csharpserver plugin is closed.

Related issue: https://github.com/BC-SECURITY/Empire/issues/609