### PR TITLE
add a fallback checkout that doesn't use a token

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -25,6 +25,13 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v2
+        if: ${{ github.repository == 'BC-SECURITY/Empire' }}
+        with:
+          submodules: 'recursive'
+      # token is only needed in sponsors repo because of private submodules
+      # don't use token in public repo because prs from forks cannot access secrets
+      - uses: actions/checkout@v2
+        if: ${{ github.repository == 'BC-SECURITY/Empire-Sponsors' }}
         with:
           submodules: 'recursive'
           token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
PRs from forks fail because they cannot access secrets. This checks which repo we are in and will not use the token in the repo for checking out in the public repo.