### PR TITLE
Fixes #540 module has no attribute 'info' in API search

### DIFF
--- a/empire/server/common/module_models.py
+++ b/empire/server/common/module_models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Dict
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, validator
 

--- a/empire/server/common/module_models.py
+++ b/empire/server/common/module_models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Dict
 
 from pydantic import BaseModel, validator
 
@@ -47,3 +47,23 @@ class PydanticModule(BaseModel):
     enabled: bool = True
     advanced: PydanticModuleAdvanced = PydanticModuleAdvanced()
     compiler_yaml: Optional[str]
+
+    def matches(self, query: str, parameter: str = "any") -> bool:
+        query = query.lower()
+        match = {
+            "name": query in self.name.lower(),
+            "description": query in self.description.lower(),
+            "comments": any(query in comment.lower() for comment in self.comments),
+            "authors": any(query in author.lower() for author in self.authors),
+        }
+
+        if parameter == "any":
+            return any(match.values())
+
+        return match[parameter]
+
+    @property
+    def info(self) -> Dict:
+        desc = self.dict(include={"name", "authors", "description", "comments"})
+        desc["options"] = [option.dict() for option in self.options]
+        return desc

--- a/empire/server/server.py
+++ b/empire/server/server.py
@@ -588,20 +588,9 @@ def start_restful_api(
 
         modules = []
 
-        for moduleName, module in main.modules.modules.items():
-            if (
-                (search_term.lower() == "")
-                or (search_term.lower() in moduleName.lower())
-                or (
-                    search_term.lower() in ("".join(module.info["Description"])).lower()
-                )
-                or (search_term.lower() in ("".join(module.info["Comments"])).lower())
-                or (search_term.lower() in ("".join(module.info["Author"])).lower())
-            ):
-                moduleInfo = copy.deepcopy(main.modules.modules[moduleName].info)
-                moduleInfo["options"] = main.modules.modules[moduleName].options
-                moduleInfo["Name"] = moduleName
-                modules.append(moduleInfo)
+        for module in main.modules.modules.values():
+            if search_term == "" or module.matches(search_term):
+                modules.append(module.info)
 
         return jsonify({"modules": modules})
 
@@ -619,14 +608,9 @@ def start_restful_api(
 
         modules = []
 
-        for moduleName, module in main.modules.modules.items():
-            if (search_term.lower() == "") or (
-                search_term.lower() in moduleName.lower()
-            ):
-                module_info = copy.deepcopy(main.modules.modules[moduleName].info)
-                module_info["options"] = main.modules.modules[moduleName].options
-                module_info["Name"] = moduleName
-                modules.append(module_info)
+        for module in main.modules.modules.values():
+            if search_term == "" or module.matches(search_term, parameter="name"):
+                modules.append(module.info)
 
         return jsonify({"modules": modules})
 
@@ -644,14 +628,9 @@ def start_restful_api(
 
         modules = []
 
-        for moduleName, module in main.modules.modules.items():
-            if (search_term.lower() == "") or (
-                search_term.lower() in ("".join(module.info["Description"])).lower()
-            ):
-                moduleInfo = copy.deepcopy(main.modules.modules[moduleName].info)
-                moduleInfo["options"] = main.modules.modules[moduleName].options
-                moduleInfo["Name"] = moduleName
-                modules.append(moduleInfo)
+        for module in main.modules.modules.values():
+            if search_term == "" or module.matches(search_term, "description"):
+                modules.append(module.info)
 
         return jsonify({"modules": modules})
 
@@ -669,14 +648,9 @@ def start_restful_api(
 
         modules = []
 
-        for moduleName, module in main.modules.modules.items():
-            if (search_term.lower() == "") or (
-                search_term.lower() in ("".join(module.info["Comments"])).lower()
-            ):
-                module_info = copy.deepcopy(main.modules.modules[moduleName].info)
-                module_info["options"] = main.modules.modules[moduleName].options
-                module_info["Name"] = moduleName
-                modules.append(module_info)
+        for module in main.modules.modules.values():
+            if search_term == "" or module.matches(search_term, "comments"):
+                modules.append(module.info)
 
         return jsonify({"modules": modules})
 
@@ -694,14 +668,9 @@ def start_restful_api(
 
         modules = []
 
-        for moduleName, module in main.modules.modules.items():
-            if (search_term.lower() == "") or (
-                search_term.lower() in ("".join(module.info["Author"])).lower()
-            ):
-                module_info = copy.deepcopy(main.modules.modules[moduleName].info)
-                module_info["options"] = main.modules.modules[moduleName].options
-                module_info["Name"] = moduleName
-                modules.append(module_info)
+        for module in main.modules.modules.values():
+            if search_term == "" or module.matches(search_term, "authors"):
+                modules.append(module.info)
 
         return jsonify({"modules": modules})
 


### PR DESCRIPTION
Fixes #540 `PydanticModule object has no attribute 'info'` in API module search.
- Checks the search query using `matches` method with an optional parameter where it looks for the term (say, description)
- Returns a dict using the `info` method (`@property`) for the respective modules