### PR TITLE
Fixxed some bugs that prevented some modules from executing correctly.

### DIFF
--- a/empire/server/common/helpers.py
+++ b/empire/server/common/helpers.py
@@ -151,8 +151,8 @@ def strip_python_comments(data):
     print(color("[!] strip_python_comments is deprecated and should not be used"))
 
     # remove docstrings
-    data = re.sub(r'""".*?"""', "", data, flags=re.DOTALL)
-    data = re.sub(r"'''.*?'''", "", data, flags=re.DOTALL)
+    data = re.sub(r'"(?<!= )""".*?"""', "", data, flags=re.DOTALL)
+    data = re.sub(r"(?<!= )'''.*?'''", "", data, flags=re.DOTALL)
 
     # remove comments
     lines = data.split("\n")

--- a/empire/server/data/agent/agent.py
+++ b/empire/server/data/agent/agent.py
@@ -170,8 +170,8 @@ def parse_task_packet(packet, offset=0):
         packetNum = struct.unpack('=H', packet[4 + offset:6 + offset])[0]
         resultID = struct.unpack('=H', packet[6 + offset:8 + offset])[0]
         length = struct.unpack('=L', packet[8 + offset:12 + offset])[0]
-        packetData = packet[12 + offset:12 + offset + length].decode('UTF-8')
-        remainingData = packet[12 + offset + length:].decode('UTF-8')
+        packetData = packet.decode('UTF-8')[12 + offset:12 + offset + length]
+        remainingData = packet.decode('UTF-8')[12 + offset + length:]
 
         return (packetType, totalPacket, packetNum, resultID, length, packetData, remainingData)
     except Exception as e:

--- a/empire/server/data/agent/ironpython_agent.py
+++ b/empire/server/data/agent/ironpython_agent.py
@@ -176,8 +176,8 @@ def parse_task_packet(packet, offset=0):
         packetNum = struct.unpack('=H', packet[4 + offset:6 + offset])[0]
         resultID = struct.unpack('=H', packet[6 + offset:8 + offset])[0]
         length = struct.unpack('=L', packet[8 + offset:12 + offset])[0]
-        packetData = packet[12 + offset:12 + offset + length].decode('UTF-8')
-        remainingData = packet[12 + offset + length:].decode('UTF-8')
+        packetData = packet.decode('UTF-8')[12 + offset:12 + offset + length]
+        remainingData = packet.decode('UTF-8')[12 + offset + length:]
 
         return (packetType, totalPacket, packetNum, resultID, length, packetData, remainingData)
     except Exception as e:

--- a/empire/server/modules/python/persistence/multi/desktopfile.py
+++ b/empire/server/modules/python/persistence/multi/desktopfile.py
@@ -52,7 +52,7 @@ if remove.lower() == "true":
 else:
     if not os.path.exists(filePath):
         os.makedirs(filePath)
-    e = open(writeFile,'wb')
+    e = open(writeFile,'w')
     e.write(dtFile)
     e.close()
 


### PR DESCRIPTION
**Changes to** `helpers.py`:
The strip_python_comments function had a regex that was stripping away docstrings comments, but docstrings are also used as multi-line strings. This caused multi-line strings to be stripped away from module payload, if it happened to have one, effectively breaking payload.

**Changes to** `desktopfile.py:`:
The module's payload was using the binary mode to write to a file but the input was a string. This works fine with Python 2, but not with Python 3.

**Changes to** `agent.py` **and** `ironpython.py`:
The function that I modified is given a string that has been AES decrypted and UTF-8 encoded, and then parses it to create multiple variables by taking bytes from certain positions. Before being UTF-8 encoded, the string might contain non-ascii characters that are 2 bytes long. This means that after being UTF-8 encoded you can no longer parse the string based on position and expect consistency. The fix is to decode the string before it gets parsed and saved into those two variables.