### PR TITLE
Fix Invoke-Kerberoast with etype 17 or 18

### DIFF
--- a/empire/server/data/module_source/credentials/Invoke-Kerberoast.ps1
+++ b/empire/server/data/module_source/credentials/Invoke-Kerberoast.ps1
@@ -629,7 +629,12 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                         $Hash = $null
                         $Out | Add-Member Noteproperty 'TicketByteHexStream' ([Bitconverter]::ToString($TicketByteStream).Replace('-',''))
                     } else {
-                        $Hash = "$($CipherText.Substring(0,32))`$$($CipherText.Substring(32))"
+                        if($Etype -eq 17 -or $Etype -eq 18) {
+                            $ChecksumLen = 24
+                        } else {
+                            $ChecksumLen = 32
+                        }
+                        $Hash = "$($CipherText.Substring(0,$ChecksumLen))`$$($CipherText.Substring($ChecksumLen))"
                         $Out | Add-Member Noteproperty 'TicketByteHexStream' $null
                     }
                 } else {

--- a/empire/server/data/module_source/situational_awareness/network/powerview.ps1
+++ b/empire/server/data/module_source/situational_awareness/network/powerview.ps1
@@ -2864,7 +2864,12 @@ Outputs a custom object containing the SamAccountName, ServicePrincipalName, and
                         $Hash = $null
                         $Out | Add-Member Noteproperty 'TicketByteHexStream' ([Bitconverter]::ToString($TicketByteStream).Replace('-',''))
                     } else {
-                        $Hash = "$($CipherText.Substring(0,32))`$$($CipherText.Substring(32))"
+                        if($Etype -eq 17 -or $Etype -eq 18) {
+                            $ChecksumLen = 24
+                        } else {
+                            $ChecksumLen = 32
+                        }
+                        $Hash = "$($CipherText.Substring(0,$ChecksumLen))`$$($CipherText.Substring($ChecksumLen))"
                         $Out | Add-Member Noteproperty 'TicketByteHexStream' $null
                     }
                 } else {


### PR DESCRIPTION
I couldn't test the code yet, but I'm pretty sure this is a bug right there. If someone could confirm, that would be great. I'm surprised the bug persisted for this long. [This](https://github.com/EmpireProject/Empire/pull/725/files) was the original commit and they seemingly made this mistake without anyone noticing.

Impacket produces working hashes of AES tickets, while `Invoke-Kerberoast` of Empire does not.

Also, it's unfortunate that `Invoke-Kerberoast` is defined twice in the code base, but that's a separate issue.

The original commit message follows.

-----------------------

AES-encrypted Kerberos service tickets (etype 17 or etype 18) use a different length checksum. This can be seen easiest in the source code of impacket:

<https://github.com/fortra/impacket/blob/32178de69075ba51d386a2973975e30533c2edd3/examples/GetUserSPNs.py#L191..L229>

It is 16 bytes for RC4 or DES tickets and 12 bytes for AES tickets. Since the code is parsing hexascii encoded binary data, the values need to be doubled. The syntax of the hash is such that a dollar sign separates the checksum from the rest of the data.

This patch inserts the dollar sign at the correct position for etypes 17 and 18.