### PR TITLE
SHABENG missing

### DIFF
--- a/setup/checkout-latest-tag.sh
+++ b/setup/checkout-latest-tag.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Get git tags matching semver
 # remove the -beta -alpha -rc suffixes with grep
 tags=$(git tag --list --sort=-version:refname "v*.*.*")


### PR DESCRIPTION
Shabeng missing is causing some strange errors when the script is executed:
```
┌──(empire3)─(kali㉿kali)-[~/opt/empire3/Empire] 2023-02-13 19:54:14 +0100
└─$ ./setup/checkout-latest-tag.sh
./setup/checkout-latest-tag.sh: 11: [[: not found
./setup/checkout-latest-tag.sh: 11: [[: not found
./setup/checkout-latest-tag.sh: 16: [: unexpected operator
./setup/checkout-latest-tag.sh: 16: [: unexpected operator
Checkout out latest tag: v4.10.0
HEAD is now at f60c62fb Merge pull request #645 from BC-SECURITY/release/4.10.0
     ```