### PR TITLE
bump version

### DIFF
--- a/empire/server/common/empire.py
+++ b/empire/server/common/empire.py
@@ -37,7 +37,7 @@ from empire.server.utils import data_util
 
 from . import agents, credentials, listeners, stagers
 
-VERSION = "5.0.0-beta2 BC Security Fork"
+VERSION = "5.0.4 BC Security Fork"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Empire still reports version `5.0.0-beta2`

This commit bumps version to `5.0.4`