### PR TITLE
Fix starkiller error in docker

### DIFF
--- a/empire/server/config.yaml
+++ b/empire/server/config.yaml
@@ -41,7 +41,7 @@ starkiller:
   # for private-main, instead of updating the submodule, just work out of a local copy.
   # So devs can work off the latest changes and not worry about accidentally updating the submodule
   # for the downstream main branches.
-  use_temp_dir: true
+  use_temp_dir: false
   auto_update: true
 plugins:
   # Auto-load plugin with defined settings


### PR DESCRIPTION
Following docker install

docker pull bcsecurity/empire:latest
docker run -it -p 1337:1337 -p 5000:5000 --volumes-from data --entrypoint /bin/bash bcsecurity/empire:latest

After running on docker:

sudo ./ps-empire server 

get Error:

![imagen](https://user-images.githubusercontent.com/48086822/224301499-4f8e3165-e46f-4f6f-a370-cd7069cebbcc.png)

Update config file to point real working directory (starkiller) instead of starkiller-temp