### PR TITLE
Fixes install.sh failed when installing Nim

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -222,6 +222,7 @@ if [ "$answer" != "${answer#[Yy]}" ] ;then
   echo "export PATH=/root/.nimble/bin:$PATH" >> ~/.bashrc
   export PATH=/root/.nimble/bin:$PATH
   SOURCE_MESSAGE=true
+  nimble install -y nimble@0.14.2
   nimble install -y winim zippy nimcrypto
   sudo apt install -y mingw-w64
 else


### PR DESCRIPTION
## Describe your changes
Explicitly specify the version of `nimble` to be installed by install.sh to `v0.14.2` where the following bugs are fixed
- https://github.com/nim-lang/nimble/pull/962

## Issue ticket number and link (if there is one)
- #690 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have updated the documentation in `docs/` (if applicable)

## Evidence
After fixing, I confirmed that `install.sh` succeeds as follows.
```
[>] Do you want to install Nim and MinGW? It is only needed to generate a Nim stager (y/N)? y
...
choosenim-init: Downloading choosenim-0.8.4_linux_amd64
  Installed component 'nim'
  Installed component 'nimble'
  Installed component 'nimgrep'
  Installed component 'nimpretty'
  Installed component 'nimsuggest'
  Installed component 'testament'
  Installed component 'nim-gdb'
   Switched to Nim 1.6.12
choosenim-init: ChooseNim installed in /root/.nimble/bin
choosenim-init: You must now ensure that the Nimble bin dir is in your PATH.
choosenim-init: Place the following line in the ~/.profile or ~/.bashrc file.
choosenim-init:     export PATH=/root/.nimble/bin:$PATH
    Prompt: No local packages.json found, download it from internet? -> [forced yes]
Downloading Official package list
    Success Package list downloaded.
Downloading https://github.com/nim-lang/nimble using git
  Verifying dependencies for nimble@0.14.2
 Installing nimble@0.14.2
   Building nimble/nimble using c backend
/tmp/nimble_157623/githubcom_nimlangnimble_0.14.2/src/nimblepkg/packageinfo.nim(155, 7) Warning: The bare except clause is deprecated; use `except CatchableError:` instead [BareExcept]
/tmp/nimble_157623/githubcom_nimlangnimble_0.14.2/src/nimblepkg/packageparser.nim(497, 9) Warning: The bare except clause is deprecated; use `except CatchableError:` instead [BareExcept]
/tmp/nimble_157623/githubcom_nimlangnimble_0.14.2/src/nimblepkg/developfile.nim(431, 7) Warning: The bare except clause is deprecated; use `except CatchableError:` instead [BareExcept]
   Warning: Symlink already exists in /root/.nimble/bin/nimble. Replacing.
   Success: nimble installed successfully.
    Prompt: winim not found in any local packages.json, check internet for updated packages? -> [forced yes]
Downloading Official package list
    Success Package list downloaded.
Downloading https://github.com/khchen/winim using git
  Verifying dependencies for winim@3.9.2
 Installing winim@3.9.2
  Success:  winim installed successfully.
Downloading https://github.com/guzba/zippy using git
  Verifying dependencies for zippy@0.10.10
 Installing zippy@0.10.10
  Success:  zippy installed successfully.
Downloading https://github.com/cheatfate/nimcrypto using git
   Warning: The package has no tagged releases, downloading HEAD instead.
  Verifying dependencies for nimcrypto@0.6.0
 Installing nimcrypto@0.6.0
  Success:  nimcrypto installed successfully.
...
[*] Checking Python version
Requirement already satisfied: poetry in /usr/lib/python3/dist-packages (1.1.12)
Requirement already satisfied: poetry-core<1.1.0,>=1.0.7 in /usr/lib/python3/dist-packages (from poetry) (1.0.7)
Requirement already satisfied: cleo<0.9.0,>=0.8.1 in /usr/lib/python3/dist-packages (from poetry) (0.8.1)
Requirement already satisfied: html5lib<2.0,>=1.0 in /usr/lib/python3/dist-packages (from poetry) (1.1)
Requirement already satisfied: clikit<0.7.0,>=0.6.2 in /usr/lib/python3/dist-packages (from poetry) (0.6.2)
Requirement already satisfied: pkginfo<2.0,>=1.4 in /usr/lib/python3/dist-packages (from poetry) (1.8.2)
Requirement already satisfied: virtualenv<21.0.0,>=20.0.26 in /usr/lib/python3/dist-packages (from poetry) (20.13.0+ds)
Requirement already satisfied: pexpect<5.0.0,>=4.7.0 in /usr/lib/python3/dist-packages (from poetry) (4.8.0)
Requirement already satisfied: requests-toolbelt<0.10.0,>=0.9.1 in /usr/lib/python3/dist-packages (from poetry) (0.9.1)
Requirement already satisfied: cachy<0.4.0,>=0.3.0 in /usr/lib/python3/dist-packages (from poetry) (0.3.0)
Requirement already satisfied: crashtest<0.4.0,>=0.3.0 in /usr/lib/python3/dist-packages (from poetry) (0.3.1)
Requirement already satisfied: packaging<21.0,>=20.4 in /usr/local/lib/python3.10/dist-packages (from poetry) (20.9)
Requirement already satisfied: tomlkit<1.0.0,>=0.7.0 in /usr/lib/python3/dist-packages (from poetry) (0.9.2)
Requirement already satisfied: keyring<22.0.0,>=21.2.0 in /usr/local/lib/python3.10/dist-packages (from poetry) (21.8.0)
Requirement already satisfied: requests<3.0,>=2.18 in /usr/lib/python3/dist-packages (from poetry) (2.25.1)
Requirement already satisfied: shellingham<2.0,>=1.1 in /usr/lib/python3/dist-packages (from poetry) (1.4.0)
Requirement already satisfied: cachecontrol[filecache]<0.13.0,>=0.12.9 in /usr/lib/python3/dist-packages (from poetry) (0.12.10)
Requirement already satisfied: lockfile>=0.9 in /usr/lib/python3/dist-packages (from cachecontrol[filecache]<0.13.0,>=0.12.9->poetry) (0.12.2)
Requirement already satisfied: SecretStorage>=3.2 in /usr/lib/python3/dist-packages (from keyring<22.0.0,>=21.2.0->poetry) (3.3.1)
Requirement already satisfied: jeepney>=0.4.2 in /usr/lib/python3/dist-packages (from keyring<22.0.0,>=21.2.0->poetry) (0.7.1)
Requirement already satisfied: pyparsing>=2.0.2 in /usr/lib/python3/dist-packages (from packaging<21.0,>=20.4->poetry) (2.4.7)
Requirement already satisfied: six<2,>=1.9.0 in /usr/lib/python3/dist-packages (from virtualenv<21.0.0,>=20.0.26->poetry) (1.16.0)
Requirement already satisfied: filelock<4,>=3.2 in /usr/lib/python3/dist-packages (from virtualenv<21.0.0,>=20.0.26->poetry) (3.6.0)
Requirement already satisfied: platformdirs<3,>=2 in /usr/lib/python3/dist-packages (from virtualenv<21.0.0,>=20.0.26->poetry) (2.5.1)
Requirement already satisfied: distlib<1,>=0.3.1 in /usr/lib/python3/dist-packages (from virtualenv<21.0.0,>=20.0.26->poetry) (0.3.4)
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
[*] Installing Packages
Creating virtualenv empire-bc-security-fork in /home/fukusuke/Empire/.venv
Installing dependencies from lock file

Package operations: 96 installs, 1 update, 0 removals

  • Installing pycparser (2.21)
  • Installing attrs (23.1.0)
  • Installing cffi (1.15.1)
  • Installing exceptiongroup (1.1.2)
  • Installing idna (3.4)
  • Installing pyasn1 (0.5.0)
  • Updating setuptools (67.8.0 -> 68.0.0)
  • Installing six (1.16.0)
  • Installing sniffio (1.3.0)
  • Installing anyio (3.7.1)
  • Installing automat (22.10.0)
  • Installing certifi (2023.5.7)
  • Installing charset-normalizer (3.2.0)
  • Installing constantly (15.1.0): Pending...
  • Installing constantly (15.1.0)
  • Installing cryptography (37.0.4): Installing...
  • Installing cryptography (37.0.4)
  • Installing greenlet (2.0.2)
  • Installing hyperlink (21.0.0)
  • Installing incremental (22.10.0)
  • Installing iniconfig (2.0.0)
  • Installing markupsafe (2.1.3)
  • Installing packaging (23.1)
  • Installing pluggy (1.2.0)
  • Installing ply (3.11)
  • Installing pyasn1-modules (0.3.0)
  • Installing tomli (2.0.1)
  • Installing typing-extensions (4.7.1)
  • Installing urllib3 (2.0.3)
  • Installing zope-interface (6.0)
  • Installing altgraph (0.17.3)
  • Installing asgiref (3.7.2)
  • Installing bcrypt (4.0.1)
  • Installing bidict (0.22.1)
  • Installing blinker (1.6.2)
  • Installing click (8.1.6)
  • Installing ecdsa (0.18.0)
  • Installing h11 (0.14.0)
  • Installing itsdangerous (2.1.2)
  • Installing jinja2 (3.1.2)
  • Installing mypy-extensions (1.0.0)
  • Installing numpy (1.24.4): Downloading... 20%
  • Installing pathspec (0.11.1)
  • Installing numpy (1.24.4)
  • Installing pathspec (0.11.1)
  • Installing platformdirs (3.9.1)
  • Installing pydantic (1.10.11)
  • Installing pygame (2.5.0)
  • Installing pyinstaller-hooks-contrib (2023.5)
  • Installing pytest (7.4.0)
  • Installing python-engineio (4.5.1)
  • Installing regex (2023.6.3)
  • Installing requests (2.31.0)
  • Installing rsa (4.9)
  • Installing service-identity (23.1.0)
  • Installing sqlalchemy (2.0.19)
  • Installing starlette (0.16.0)
  • Installing stone (3.3.1)
  • Installing twisted (22.10.0)
  • Installing wcwidth (0.2.6)
  • Installing websocket-client (1.6.1)
  • Installing werkzeug (2.3.6)
  • Installing xlrd (2.0.1)
  • Installing xlwt (1.3.0)
  • Installing aiofiles (0.7.0)
  • Installing black (23.7.0): Installing...
  • Installing docopt (0.6.2): Preparing...
  • Installing black (23.7.0)
  • Installing docopt (0.6.2)
  • Installing donut-shellcode (1.0.2)
  • Installing dropbox (11.36.2)
  • Installing fastapi (0.70.0)
  • Installing flask (2.3.2)
  • Installing humanize (3.14.0)
  • Installing iptools (0.7.0)
  • Installing isort (5.12.0)
  • Installing jq (1.4.1)
  • Installing macholib (1.16.2)
  • Installing netifaces (0.11.0)
  • Installing passlib (1.7.4)
  • Installing prompt-toolkit (3.0.39)
  • Installing pycryptodome (3.18.0)
  • Installing pyinstaller (5.13.0)
  • Installing pymysql (0.10.1)
  • Installing pyopenssl (22.0.0)
  • Installing pyparsing (3.1.0)
  • Installing pyperclip (1.8.2)
  • Installing pysecretsocks (0.9.1 43c0bed)
  • Installing pytest-timeout (2.1.0)
  • Installing python-jose (3.3.0)
  • Installing python-multipart (0.0.5)
  • Installing python-obfuscator (0.0.2)
  • Installing python-socketio (5.8.0)
  • Installing pyvnc (0.1 a565e9b)
  • Installing pyyaml (6.0.1)
  • Installing ruff (0.0.233)
  • Installing sqlalchemy-utc (0.14.0)
  • Installing terminaltables (3.1.10)
  • Installing uvicorn (0.14.0)
  • Installing websockets (10.4)
  • Installing websockify (0.10.0)
  • Installing xlutils (2.0.0)
  • Installing zlib-wrapper (0.1.3)

Installing the current project: empire-bc-security-fork (5.5.4)
[+] Install Complete!

[+] Run the following commands in separate terminals to start Empire
[*] ./ps-empire server
[*] ./ps-empire client
[*] source ~/.bashrc to enable nim
```
