### PR TITLE
corrected "selected" field assignment in InteractMenu.py

### DIFF
--- a/empire/client/src/menus/InteractMenu.py
+++ b/empire/client/src/menus/InteractMenu.py
@@ -161,7 +161,7 @@ class InteractMenu(Menu):
         state.get_agents()
         if agent_name in state.agents.keys():
             self.name = agent_name
-            self.selected = state.agents[agent_name]["session_id"]
+            self.selected = agent_name
             self.session_id = state.agents[agent_name]["session_id"]
             self.agent_options = state.agents[agent_name]  # todo rename agent_options
             self.agent_language = self.agent_options["language"]

--- a/empire/client/src/menus/ShellMenu.py
+++ b/empire/client/src/menus/ShellMenu.py
@@ -91,7 +91,7 @@ class ShellMenu(Menu):
 
         Usage:  <shell_cmd>
         """
-        response = state.agent_shell(agent_name, shell_cmd)
+        response = state.agent_shell(state.agents[agent_name]["session_id"], shell_cmd)
         if shell_cmd.split()[0].lower() in ["cd", "set-location"]:
             shell_return = threading.Thread(
                 target=self.update_directory, args=[agent_name]

--- a/empire/client/src/menus/ShellMenu.py
+++ b/empire/client/src/menus/ShellMenu.py
@@ -94,7 +94,7 @@ class ShellMenu(Menu):
         response = state.agent_shell(state.agents[agent_name]["session_id"], shell_cmd)
         if shell_cmd.split()[0].lower() in ["cd", "set-location"]:
             shell_return = threading.Thread(
-                target=self.update_directory, args=[agent_name]
+                target=self.update_directory, args=[state.agents[agent_name]["session_id"]]
             )
             shell_return.daemon = True
             shell_return.start()

--- a/empire/client/src/menus/UseModuleMenu.py
+++ b/empire/client/src/menus/UseModuleMenu.py
@@ -114,7 +114,7 @@ class UseModuleMenu(UseMenu):
                 log.error("Agent not set")
                 return
             response = state.execute_module(
-                self.record_options["Agent"]["value"], post_body
+                state.agents[self.record_options["Agent"]["value"]]["session_id"], post_body
             )
             if "status" in response.keys():
                 if "Agent" in post_body["options"].keys():


### PR DESCRIPTION
The "selected" field in the InteractMenu was not assigned correctly before. I changed it to assign the agent_name to the "selected" field, similarly as in other menus. Without this correction if you rename an agent, interact with its new name, and issue the "shell" command, the client will crash because it will try to find the agent in "state.agents" by session ID, even though it should search by name. Exception that occurs in this case without my correction:

(Empire: web05) > shell
Traceback (most recent call last):
  File "/home/tamas/repos/Empire/empire.py", line 26, in <module>
    client.start(args)
  File "/home/tamas/repos/Empire/empire/client/client.py", line 508, in start
    empire.main()
  File "/home/tamas/repos/Empire/empire/client/client.py", line 261, in main
    self.parse_command_line(text, cmd_line)
  File "/home/tamas/repos/Empire/empire/client/client.py", line 363, in parse_command_line
    menu_state.push(
  File "/home/tamas/repos/Empire/empire/client/src/MenuState.py", line 22, in push
    if menu.on_enter(**kwargs):
       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tamas/repos/Empire/empire/client/src/menus/ShellMenu.py", line 31, in on_enter
    self.use(kwargs["selected"])
  File "/home/tamas/repos/Empire/empire/client/src/menus/ShellMenu.py", line 50, in use
    self.session_id = state.agents[self.selected]["session_id"]
                      ~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'F7EZCSH9'


