### PR TITLE
Fix various Python 3.12 SyntaxWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Fixed various Python 3.12 SyntaxWarning
+
 ## [5.11.4] - 2024-09-04
 
 ### Added

--- a/empire/server/data/agent/ironpython_agent.py
+++ b/empire/server/data/agent/ironpython_agent.py
@@ -1393,7 +1393,7 @@ class MainAgent:
                                 if (-not $($o.User)) {
                                     $o = 'N/A'
                                 } else {
-                                    $o = "$($o.Domain)\$($o.User)"
+                                    $o = "$($o.Domain)\\$($o.User)"
                                 }
                             } catch {
                                 $o = 'N/A'

--- a/empire/server/data/module_source/python/privesc/linuxprivchecker.py
+++ b/empire/server/data/module_source/python/privesc/linuxprivchecker.py
@@ -333,22 +333,22 @@ def search_file_perms():
 
     fdperms = {
         "WWDIRSROOT": {
-            "cmd": "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null | grep root",
+            "cmd": r"find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null | grep root",
             "msg": "World Writeable Directories for User/Group 'Root'",
             "results": [],
         },
         "WWDIRS": {
-            "cmd": "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null | grep -v root",
+            "cmd": r"find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null | grep -v root",
             "msg": "World Writeable Directories for Users other than Root",
             "results": [],
         },
         "WWFILES": {
-            "cmd": "find / \( -wholename '/home/homedir/*' -prune -o -wholename '/proc/*' -prune \) -o \( -type f -perm -0002 \) -exec ls -l '{}' ';' 2>/dev/null",
+            "cmd": r"find / \( -wholename '/home/homedir/*' -prune -o -wholename '/proc/*' -prune \) -o \( -type f -perm -0002 \) -exec ls -l '{}' ';' 2>/dev/null",
             "msg": "World Writable Files",
             "results": [],
         },
         "SUID": {
-            "cmd": "find / \( -perm -2000 -o -perm -4000 \) -exec ls -ld {} \; 2>/dev/null",
+            "cmd": r"find / \( -perm -2000 -o -perm -4000 \) -exec ls -ld {} \; 2>/dev/null",
             "msg": "SUID/SGID Files and Directories",
             "results": [],
         },
@@ -1171,7 +1171,7 @@ def run_check():
     bigline = "======================================================================================="
     print(bigline)
     print(
-        """
+        r"""
         __    _                  ____       _       ________              __
        / /   (_)___  __  ___  __/ __ \_____(_)   __/ ____/ /_  ___  _____/ /_____  _____
       / /   / / __ \/ / / / |/_/ /_/ / ___/ / | / / /   / __ \/ _ \/ ___/ //_/ _ \/ ___/


### PR DESCRIPTION
Python 3.12 is getting more chatty about some syntax warnings:

```
/usr/share/powershell-empire/empire/server/data/agent/ironpython_agent.py:1388: SyntaxWarning: invalid escape sequence '\$'
  """
/usr/share/powershell-empire/empire/server/data/module_source/python/privesc/linuxprivchecker.py:336: SyntaxWarning: invalid e
scape sequence '\('
  "cmd": "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null | gre
p root",
/usr/share/powershell-empire/empire/server/data/module_source/python/privesc/linuxprivchecker.py:341: SyntaxWarning: invalid e
scape sequence '\('
  "cmd": "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null | gre
p -v root",
/usr/share/powershell-empire/empire/server/data/module_source/python/privesc/linuxprivchecker.py:346: SyntaxWarning: invalid e
scape sequence '\('
  "cmd": "find / \( -wholename '/home/homedir/*' -prune -o -wholename '/proc/*' -prune \) -o \( -type f -perm -0002 \) -exec l
s -l '{}' ';' 2>/dev/null",
/usr/share/powershell-empire/empire/server/data/module_source/python/privesc/linuxprivchecker.py:351: SyntaxWarning: invalid e
scape sequence '\('
  "cmd": "find / \( -perm -2000 -o -perm -4000 \) -exec ls -ld {} \; 2>/dev/null",
/usr/share/powershell-empire/empire/server/data/module_source/python/privesc/linuxprivchecker.py:1174: SyntaxWarning: invalid 
escape sequence '\_'
  """
```