### PR TITLE
fix mysql service name typo

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -63,7 +63,7 @@ jobs:
           cache: 'poetry'
       - name: Set up MySQL
         run: |
-          sudo systemctl start mysql
+          sudo systemctl start mysqld
           mysql -u root -proot -e "CREATE USER IF NOT EXISTS 'empire_user'@'localhost' IDENTIFIED BY 'empire_password';" || true
           mysql -u root -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'empire_user'@'localhost' WITH GRANT OPTION;" || true
           mysql -u root -proot -e "FLUSH PRIVILEGES;" || true

--- a/empire/server/core/db/base.py
+++ b/empire/server/core/db/base.py
@@ -38,7 +38,7 @@ def try_create_engine(engine_url: str, *args, **kwargs) -> Engine:
         log.error(e, exc_info=True)
         log.error(f"Failed connecting to database using {engine_url}")
         log.error("Perhaps the MySQL service is not running.")
-        log.error("Try executing: sudo systemctl start mysql")
+        log.error("Try executing: sudo systemctl start mysqld")
         sys.exit(1)
 
     return engine

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -74,7 +74,7 @@ function install_mysql() {
 
 function start_mysql() {
   echo -e "\x1b[1;34m[*] Configuring MySQL\x1b[0m"
-  sudo systemctl start mysql.service || true # will fail in a docker image
+  sudo systemctl start mysqld.service || true # will fail in a docker image
 
   # Add the default empire user to the mysql database
   sudo mysql -u root -e "CREATE USER IF NOT EXISTS 'empire_user'@'localhost' IDENTIFIED BY 'empire_password';" || true


### PR DESCRIPTION
## Describe your changes
The MySQL service name is not `mysql` anymore but `mysqld`.

## Issue ticket number and link (if there is one)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have updated the documentation in `docs/` (if applicable)
