### PR TITLE
Fixing delay/jitter adjustment in python agent (#764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Fix delay/jitter adjustment in python agent (@janit0rjoe)
+
 ## [5.12.0] - 2024-12-14
 
 -   Reduce the check-in tests that were adding an unncessary amount of time to the CI

--- a/empire/server/core/agent_task_service.py
+++ b/empire/server/core/agent_task_service.py
@@ -270,7 +270,7 @@ class AgentTaskService:
                 db,
                 agent,
                 "TASK_CMD_WAIT",
-                f"global delay; global jitter; delay={delay}; jitter={jitter}; print('delay/jitter set to {delay}/{jitter}')",
+                f"global agent; agent.delay={delay}; agent.jitter={jitter}; print('delay/jitter set to {delay}/{jitter}')",
                 user_id=user_id,
             )
         if agent.language == "csharp":

--- a/empire/server/data/agent/agent.py
+++ b/empire/server/data/agent/agent.py
@@ -621,6 +621,7 @@ class MainAgent:
         Task 100
         """
         try:
+            globals().update({'agent':self})
             buffer = StringIO()
             sys.stdout = buffer
             code_obj = compile(data, "<string>", "exec")


### PR DESCRIPTION
## Describe your changes
The MainAgent object of the running agent (self) has been added to globals() in [empire/server/data/agent/agent.py](https://github.com/BC-SECURITY/Empire/blob/main/empire/server/data/agent/agent.py) right before executing the received python statement.
The python statement itself in [empire/server/core/agent_task_service.py](https://github.com/BC-SECURITY/Empire/blob/main/empire/server/core/agent_task_service.py) has been adjusted to edit the delay and jitter attributes of the MainAgent object.

Screenshot of working delay:
![agent_sleep20_fix](https://github.com/user-attachments/assets/9dd8c365-d59b-476f-8a11-1fb597c0b2e6)

## Issue ticket number and link (if there is one)
#764 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have updated the documentation in `docs/` (if applicable)
