### PR TITLE
Fixed C# exe failing generation when set to PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed issue with C# exe and shellcode not compiling PowerShell stagers
+
 ## [5.12.1] - 2025-01-08
 
 ### Fixed

--- a/empire/server/server.py
+++ b/empire/server/server.py
@@ -86,7 +86,9 @@ def reset():
         f"{CSHARP_DIR_BASE}/Data/Tasks/CSharp/Compiled/netcoreapp3.0"
     )
 
-    file_util.clear_file_contents(f"{CSHARP_DIR_BASE}/Data/EmbeddedResources/launcher.txt")
+    file_util.clear_file_contents(
+        f"{CSHARP_DIR_BASE}/Data/EmbeddedResources/launcher.txt"
+    )
 
     if os.path.exists(empire_config.starkiller.directory):
         shutil.rmtree(empire_config.starkiller.directory)
@@ -94,6 +96,7 @@ def reset():
     file_util.remove_file("data/sessions.csv")
     file_util.remove_file("data/credentials.csv")
     file_util.remove_file("data/master.log")
+
 
 def shutdown_handler(signum, frame):
     """

--- a/empire/server/server.py
+++ b/empire/server/server.py
@@ -86,13 +86,14 @@ def reset():
         f"{CSHARP_DIR_BASE}/Data/Tasks/CSharp/Compiled/netcoreapp3.0"
     )
 
+    file_util.clear_file_contents(f"{CSHARP_DIR_BASE}/Data/EmbeddedResources/launcher.txt")
+
     if os.path.exists(empire_config.starkiller.directory):
         shutil.rmtree(empire_config.starkiller.directory)
 
     file_util.remove_file("data/sessions.csv")
     file_util.remove_file("data/credentials.csv")
     file_util.remove_file("data/master.log")
-
 
 def shutdown_handler(signum, frame):
     """

--- a/empire/server/stagers/CSharpPS.yaml
+++ b/empire/server/stagers/CSharpPS.yaml
@@ -37,15 +37,15 @@
 
           using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourceName)))
           {
-              string script = reader.ReadToEnd();
-              ps.AddScript(script);
+            string script = reader.ReadToEnd();
+            ps.AddScript(script);
           }
           ps.Invoke();
 
         }
         catch (Exception e)
         {
-            Console.WriteLine("Error: " + e.Message.ToString());
+          Console.WriteLine("Error: " + e.Message.ToString());
         }
       }
     }

--- a/empire/server/stagers/CSharpPS.yaml
+++ b/empire/server/stagers/CSharpPS.yaml
@@ -20,28 +20,28 @@
     using System.Management.Automation.Runspaces;
     using System.IO;
     using System.Reflection;
-    
+
     public static class Program
     {
       public static void Main(string[] args)
       {
-  
+
         PowerShell ps = PowerShell.Create();
-  
+
         try
         {
           var assembly = Assembly.GetExecutingAssembly();
           var resourceName = "launcher.txt";
-  
+
           string[] names = assembly.GetManifestResourceNames();
-  
+
           using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourceName)))
           {
               string script = reader.ReadToEnd();
               ps.AddScript(script);
           }
           ps.Invoke();
-  
+
         }
         catch (Exception e)
         {

--- a/empire/server/stagers/CSharpPS.yaml
+++ b/empire/server/stagers/CSharpPS.yaml
@@ -23,32 +23,31 @@
     
     public static class Program
     {
-          public static void Main(string[] args)
+      public static void Main(string[] args)
+      {
+  
+        PowerShell ps = PowerShell.Create();
+  
+        try
+        {
+          var assembly = Assembly.GetExecutingAssembly();
+          var resourceName = "launcher.txt";
+  
+          string[] names = assembly.GetManifestResourceNames();
+  
+          using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourceName)))
           {
-
-            PowerShell ps = PowerShell.Create();
-
-            try
-            {
-              var assembly = Assembly.GetExecutingAssembly();
-              var resourceName = "launcher.txt";
-
-              string[] names = assembly.GetManifestResourceNames();
-
-              using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourceName)))
-              {
-                  string script = reader.ReadToEnd();
-                  ps.AddScript(script);
-              }
-              ps.Invoke();
-    
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Error: " + e.Message.ToString());
-            }
-
+              string script = reader.ReadToEnd();
+              ps.AddScript(script);
           }
+          ps.Invoke();
+  
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Error: " + e.Message.ToString());
+        }
+      }
     }
   TaskingType: Assembly
   UnsafeCompile: false

--- a/empire/server/utils/file_util.py
+++ b/empire/server/utils/file_util.py
@@ -27,17 +27,19 @@ def remove_file(path: str) -> None:
     if os.path.exists(path):
         os.remove(path)
 
+
 def clear_file_contents(path: str) -> None:
     """
     Clears the contents of a file without deleting it.
     If the file doesn't exist, it creates an empty file.
     """
     try:
-        with open(path, 'w'):
+        with open(path, "w"):
             pass
         log.debug(f"Cleared contents of the file: {path}")
     except Exception as e:
         log.error(f"Failed to clear file contents for {path}: {e}", exc_info=True)
+
 
 def run_as_user(command, user=None, cwd=None):
     """

--- a/empire/server/utils/file_util.py
+++ b/empire/server/utils/file_util.py
@@ -27,6 +27,17 @@ def remove_file(path: str) -> None:
     if os.path.exists(path):
         os.remove(path)
 
+def clear_file_contents(path: str) -> None:
+    """
+    Clears the contents of a file without deleting it.
+    If the file doesn't exist, it creates an empty file.
+    """
+    try:
+        with open(path, 'w'):
+            pass
+        log.debug(f"Cleared contents of the file: {path}")
+    except Exception as e:
+        log.error(f"Failed to clear file contents for {path}: {e}", exc_info=True)
 
 def run_as_user(command, user=None, cwd=None):
     """


### PR DESCRIPTION
## Describe your changes
Fixed an issue where not having a launcher.txt file present on startup will cause the powershell option to fail for C# exes and shellcode.

## Issue ticket number and link (if there is one)
https://github.com/BC-SECURITY/Empire/issues/761

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have updated the documentation in `docs/` (if applicable)
