### PR TITLE
Module Description Standardization

### DIFF
--- a/empire/server/modules/powershell/collection/clipboard_monitor.yaml
+++ b/empire/server/modules/powershell/collection/clipboard_monitor.yaml
@@ -4,8 +4,7 @@ authors:
   - name: Will Schroeder
     handle: '@harmj0y'
     link: https://twitter.com/harmj0y
-description: Monitors the clipboard on a specified interval for changes to copied
-  text.
+description: Continuously monitors and logs clipboard content changes on the target system. Helpful in tracking copied passwords or sensitive data used during a session.
 software: ''
 tactics: [TA0009]
 techniques: [T1115, T1082]

--- a/empire/server/modules/powershell/collection/keylogger.yaml
+++ b/empire/server/modules/powershell/collection/keylogger.yaml
@@ -10,8 +10,11 @@ authors:
   - name: Will Schroeder
     handle: '@harmj0y'
     link: https://twitter.com/harmj0y
-description: Logs keys pressed, time and the active window (when changed) to the
-  keystrokes.txt file. This file is located in the agents downloads directory Empire/downloads/<AgentName>/keystrokes.txt.
+description: Captures and logs keystrokes, active window titles, and timestamps on the target system. 
+  The keystrokes are stored in a file named `keystrokes.txt` within the path `Empire/downloads/<AgentName>/`.
+  This module can be used to collect sensitive input such as passwords, messages, or command-line usage over time.
+  It supports optional sleep delay between key reads to reduce CPU usage and increase stealth. 
+  This technique is often used for credential access, user monitoring, or activity logging during post-exploitation.
 software: ''
 tactics: [TA0006, TA0009]
 techniques: [T1056.001]

--- a/empire/server/modules/powershell/collection/screenshot.yaml
+++ b/empire/server/modules/powershell/collection/screenshot.yaml
@@ -7,8 +7,7 @@ authors:
   - name: Will Schroeder
     handle: '@harmj0y'
     link: https://twitter.com/harmj0y
-description: Takes a screenshot of the current desktop and returns the output as
-  a .PNG.
+description: Captures a screenshot of the target user's desktop. Useful for spying on user activity or capturing sensitive information displayed on the screen.
 software: ''
 tactics: [TA0009]
 techniques: [T1113]

--- a/empire/server/modules/powershell/collection/toasted.yaml
+++ b/empire/server/modules/powershell/collection/toasted.yaml
@@ -7,9 +7,13 @@ authors:
   - name: Empire implementation by @Quickbreach
     handle: ''
     link: ''
-description: Spawns a native toast notification that, if clicked, prompts the current
-  user to enter their credentials into a native looking prompt. Notification stays
-  on screen for ~25 seconds. Requires Windows >= 8.1/2012
+description: Displays a native-looking Windows toast notification that, when clicked by the user,
+  opens a credential prompt impersonating a system or application message.
+  The goal is to phish user credentials by mimicking legitimate Windows dialogs,
+  such as those related to system updates or restart prompts.
+  Captured credentials can be optionally verified, and the prompt may reappear until valid input is provided.
+  This module targets Windows systems (version 8.1 / Server 2012 or newer) and is useful in
+  social engineering or post-exploitation scenarios.
 software: ''
 tactics: [TA0006, TA0009]
 techniques: [T1056.002]

--- a/empire/server/modules/powershell/credentials/DomainPasswordSpray.yaml
+++ b/empire/server/modules/powershell/credentials/DomainPasswordSpray.yaml
@@ -4,8 +4,7 @@ authors:
   - name: ''
     handle: '@dafthack'
     link: ''
-description: DomainPasswordSpray is a tool written in PowerShell to perform a password
-  spray attack against users of a domain.
+description: Performs a domain password spray attack against user accounts with lockout safeguards, automatically throttling attempts to avoid triggering account lockouts. Supports single passwords or custom lists, and can generate target user lists from Active Directory or accept predefined inputs. Outputs results to a file for tracking.
 software: ''
 tactics: [TA0006]
 techniques: [T1110.004]

--- a/empire/server/modules/powershell/credentials/credential_injection.yaml
+++ b/empire/server/modules/powershell/credentials/credential_injection.yaml
@@ -4,9 +4,11 @@ authors:
   - name: Joseph Bialek
     handle: '@JosephBialek'
     link: https://twitter.com/JosephBialek
-description: Runs PowerSploit's Invoke-CredentialInjection to create logons with
-  clear-text credentials without triggering a suspicious Event ID 4648 (Explicit
-  Credential Logon).
+description: Performs credential injection via Windows logon processes while evading Event ID 4648 logging.  
+  Key features - 
+  - Injects clear-text credentials into `WinLogon.exe` (new/existing processes)  
+  - Supports multiple logon types (`Interactive`, `NetworkCleartext`, etc.)  
+  - Bypasses default credential logging via `Msv1_0`/`Kerberos` package selection 
 software: S0194
 tactics: [TA0004, TA0005]
 techniques: [T1078]

--- a/empire/server/modules/powershell/credentials/enum_cred_store.yaml
+++ b/empire/server/modules/powershell/credentials/enum_cred_store.yaml
@@ -4,8 +4,7 @@ authors:
   - name: BeetleChunks
     handle: ''
     link: ''
-description: Dumps plaintext credentials from the Windows Credential Manager for
-  the current interactive user.
+description: Extracts plaintext credentials from the current user's Windows Credential Manager vault, including saved logins for websites, RDP sessions, and other applications. Operates without admin privileges but requires interactive user context.
 software: ''
 tactics: [TA0006]
 techniques: [T1555.004, T1003]

--- a/empire/server/modules/powershell/credentials/get_lapspasswords.yaml
+++ b/empire/server/modules/powershell/credentials/get_lapspasswords.yaml
@@ -7,7 +7,7 @@ authors:
   - name: n0decaf
     handle: ''
     link: ''
-description: Dumps user readable LAPS passwords using kfosaaen's Get-LAPSPasswords.
+description: Retrieves readable LAPS (Local Administrator Password Solution) passwords from Active Directory for domain-joined systems using kfosaaen's Get-LAPSPasswords. Supports multiple output formats (JSON, CSV, etc.) for integration with other tools. Requires domain user privileges but avoids admin rights.
 software: ''
 tactics: [TA0006]
 techniques: [T1003.006]

--- a/empire/server/modules/powershell/credentials/invoke_internal_monologue.yaml
+++ b/empire/server/modules/powershell/credentials/invoke_internal_monologue.yaml
@@ -8,12 +8,7 @@ authors:
     handle: '@4lex'
     link: ''
 description: |
-  Uses the Internal Monologue attack to force easily-decryptable Net-NTLMv1
-  responses over localhost and without directly touching LSASS. The underlying powershell
-  function accepts switches that [DISABLE] default behaviours. The default settings will
-  downgrade NetNTLM responses to v1, impersonate all users, use challenge 1122334455667788
-  and restore the registry to its original state. Set the options in this module to True
-  in order to DISABLE the behaviours
+  Forces Net-NTLMv1 authentication responses over localhost via registry manipulation without LSASS interaction, using a fixed challenge (1122334455667788) for easy decryption. Default settings downgrade to v1, impersonate all users, and restore the registry; toggle options to disable these behaviors.
 software: ''
 tactics: [TA0006]
 techniques: [T1003.001]

--- a/empire/server/modules/powershell/credentials/invoke_kerberoast.yaml
+++ b/empire/server/modules/powershell/credentials/invoke_kerberoast.yaml
@@ -7,8 +7,7 @@ authors:
   - name: ''
     handle: '@machosec'
     link: ''
-description: Requests kerberos tickets for all users with a non-null service principal
-  name (SPN) and extracts them into a format ready for John or Hashcat.
+description: Requests Kerberos service tickets for accounts with SPNs and extracts them into John/Hashcat-crackable formats, optionally targeting privileged accounts (AdminSDHolder) or custom LDAP queries. Operates with standard domain user privileges and outputs in multiple formats (JSON, CSV, etc.).
 software: ''
 tactics: [TA0006]
 techniques: [T1558.003]

--- a/empire/server/modules/powershell/credentials/invoke_ntlmextract.yaml
+++ b/empire/server/modules/powershell/credentials/invoke_ntlmextract.yaml
@@ -4,7 +4,7 @@ authors:
   - name: Tobias Heilig
     handle: ''
     link: ''
-description: Extract local NTLM password hashes from the registry.
+description: Extracts local NTLM password hashes from the SAM registry hive without directly accessing LSASS, requiring administrative privileges. Retrieves both user and machine account hashes stored in HKLM\SAM for offline cracking.
 software: ''
 tactics: [TA0006]
 techniques: [T1003.002, T1552.002]

--- a/empire/server/modules/powershell/credentials/mimikatz/command.yaml
+++ b/empire/server/modules/powershell/credentials/mimikatz/command.yaml
@@ -7,7 +7,10 @@ authors:
   - name: Benjamin Delpy
     handle: '@gentilkiwi'
     link: https://twitter.com/gentilkiwi
-description: "Runs PowerSploit's Invoke-Mimikatz function with a custom command.
+description: Executes PowerSploit's `Invoke-Mimikatz` function with a user-defined command to extract credentials, 
+  manipulate tokens, or perform other post-exploitation activities on Windows systems. 
+  While some functions (e.g., token listing) work without administrative privileges, 
+  most operations (like credential dumping) require elevated rights.
   Note: Not all functions require admin, but many do."
 software: S0002
 tactics: [TA0006, TA0009]

--- a/empire/server/modules/powershell/exfiltration/Invoke_ExfilDataToGitHub.yaml
+++ b/empire/server/modules/powershell/exfiltration/Invoke_ExfilDataToGitHub.yaml
@@ -4,8 +4,12 @@ authors:
   - name: Nga Hoang
     handle: ''
     link: ''
-description: Use this module to exfil files and data to GitHub. Requires the pre-generation
-  of a GitHub Personal Access Token.
+description: Exfiltrates data to GitHub repositories via authenticated API calls.  
+  Key features -  
+  - Uses GitHub's REST API with Personal Access Tokens (PAT) for authentication  
+  - Supports both file uploads (`LocalFilePath`) and direct data insertion (`Data` parameter)  
+  - Allows recursive directory uploads and file filtering (e.g., `*.pdf`)  
+  - Base64-encoded PAT for minimal credential exposure 
 software: ''
 tactics: [TA0010]
 techniques: [T1567.001]

--- a/empire/server/modules/powershell/exfiltration/PSRansom.yaml
+++ b/empire/server/modules/powershell/exfiltration/PSRansom.yaml
@@ -4,7 +4,11 @@ authors:
   - name: ''
     handle: '@JoelGMSec'
     link: ''
-description: PSRansom is a PowerShell Ransomware Simulator with C2 Server capabilities.
+description:   PowerShell-based ransomware simulator with C2 exfiltration capabilities.  
+  Primary functions - 
+  - File encryption/decryption (AES-256) with recovery key support  
+  - Optional C2 data exfiltration during encryption  
+  - Demonstration mode (wallpaper change + ransom note popup)
 software: ''
 tactics: [TA0040]
 techniques: [T1486, T1491.001, T1140, T1083]

--- a/empire/server/modules/powershell/exfiltration/egresscheck.yaml
+++ b/empire/server/modules/powershell/exfiltration/egresscheck.yaml
@@ -4,8 +4,14 @@ authors:
   - name: Stuart Morgan <stuart.morgan@mwrinfosecurity.com>
     handle: ''
     link: ''
-description: This module will generate traffic on a provided range of ports and supports
-  both TCP and UDP. Useful to identify direct egress channels.
+description: Tests network egress filtering by attempting outbound connections across specified ports/protocols (TCP/UDP).
+  Key features -
+  - Identifies allowed/blocked egress paths for C2 communication
+  - Supports port ranges (e.g., 22-25) and custom delays between tests
+  - Useful for -
+    * Bypassing firewall restrictions
+    * Identifying accidental port openings
+    * Planning exfiltration routes.
 software: ''
 tactics: [TA0007]
 techniques: [T1016.001]

--- a/empire/server/modules/powershell/exfiltration/exfil_dropbox.yaml
+++ b/empire/server/modules/powershell/exfiltration/exfil_dropbox.yaml
@@ -7,7 +7,12 @@ authors:
   - name: Laurent Kempe
     handle: ''
     link: ''
-description: 'Upload a file to dropbox '
+description: 'Uploads files to Dropbox via API for controlled exfiltration or staging.  
+  Key features - 
+  - Uses Dropbox's v2 API with OAuth 2.0 (Bearer token) for authentication  
+  - Supports file overwrite/autorename (configurable via API parameters)  
+  - Operates over HTTPS (blends with legitimate traffic)  
+  - Preserves original timestamps and metadata'
 software: ''
 tactics: [TA0010]
 techniques: [T1567.002]


### PR DESCRIPTION
Updated 14 module descriptions to align with Empire 6.0 LLM requirements:

### Credential Modules
- `DomainPasswordSpray`
- `credential_injection`
- `enum_cred_store`
- `get_lapspasswords`
- `invoke_kerberoast`
- `invoke_ntlmextract`

### Collection Modules  
- `keylogger`
- `toasted`

### Exfiltration Modules
- `Invoke_ExfilDataToGitHub'
- `exfil_dropbox`
- `egresscheck`

### Special Cases
- `invoke_internal_monologue`
- `PSRansom`
- `mimikatz/command`