### PR TITLE
Fix/port normalization overrides host port

### DIFF
--- a/empire/server/core/listener_service.py
+++ b/empire/server/core/listener_service.py
@@ -245,7 +245,7 @@ class ListenerService:
             value = option_meta["Value"]
             # parse and auto-set some host parameters
             if option_name == "Host":
-                host_rexp = r'^(https?)?:?/?/?([^:]+):?(\d+)?$'
+                host_rexp = r"^(https?)?:?/?/?([^:]+):?(\d+)?$"
                 matches = re.match(host_rexp, value)
                 try:
                     protocol, host, port = matches.groups()
@@ -255,12 +255,14 @@ class ListenerService:
                     host = value
                     port = None
                 if not protocol:
-                    if ("CertPath" in instance.options and
-                          instance.options["CertPath"]["Value"] != ""):
+                    if (
+                        "CertPath" in instance.options
+                        and instance.options["CertPath"]["Value"] != ""
+                    ):
                         protocol = "https"
                     else:
                         protocol = "http"
-                if protocol == "https"
+                if protocol == "https":
                     default_port = 443
                 else:
                     default_port = 80
@@ -272,14 +274,9 @@ class ListenerService:
                     else:
                         instance.options["Port"]["Value"] = default_port
                 if port:
-                    instance.options["Host"]["Value"] = "{}://{}:{}".format(
-                        protocol,
-                        host,
-                        port)
+                    instance.options["Host"]["Value"] = f"{protocol}://{host}:{port}"
                 else:
-                    instance.options["Host"]["Value"] = "{}://{}".format(
-                        protocol,
-                        host)
+                    instance.options["Host"]["Value"] = f"{protocol}://{host}"
 
             elif option_name == "CertPath" and value != "":
                 instance.options[option_name]["Value"] = value
@@ -294,11 +291,12 @@ class ListenerService:
                 instance.options[option_name]["Value"] = value
                 # Check if Port is set and add it to host
                 try:
-                  protocol, host, port = instance.options["Host"]["Value"].split(':')
+                    protocol, host, port = instance.options["Host"]["Value"].split(":")
                 except ValueError:
-                  instance.options["Host"]["Value"] = "{}:{}".format(
-                      instance.options["Host"]["Value"],
-                      instance.options["Port"]["Value"])
+                    instance.options["Host"]["Value"] = "{}:{}".format(
+                        instance.options["Host"]["Value"],
+                        instance.options["Port"]["Value"],
+                    )
 
             elif option_name == "StagingKey":
                 # if the staging key isn't 32 characters, assume we're md5 hashing it

--- a/empire/test/test_listener_api.py
+++ b/empire/test/test_listener_api.py
@@ -122,7 +122,9 @@ def test_create_listener_template_not_found(client, admin_auth_header):
     assert response.json()["detail"] == "Listener Template qwerty not found"
 
 
-def test_create_listener_normalization_adds_protocol_and_default_port(client, admin_auth_header):
+def test_create_listener_normalization_adds_protocol_and_default_port(
+    client, admin_auth_header
+):
     base_listener = get_base_listener()
     base_listener["name"] = "temp123"
     base_listener["options"]["Host"] = "localhost"
@@ -133,8 +135,8 @@ def test_create_listener_normalization_adds_protocol_and_default_port(client, ad
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["options"]["Host"] == "http://localhost:80"
-    assert response.json()["options"]["Port"] == '80'
-    
+    assert response.json()["options"]["Port"] == "80"
+
     client.delete(
         f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
     )
@@ -144,39 +146,43 @@ def test_create_listener_normalization_adds_port_to_host(client, admin_auth_head
     base_listener = get_base_listener()
     base_listener["name"] = "temp123"
     base_listener["options"]["Host"] = "http://localhost"
-    base_listener["options"]["Port"] = '1234'
+    base_listener["options"]["Port"] = "1234"
 
     response = client.post(
         "/api/v2/listeners/", headers=admin_auth_header, json=base_listener
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["options"]["Host"] == "http://localhost:1234"
-    assert response.json()["options"]["Port"] == '1234'
-    
+    assert response.json()["options"]["Port"] == "1234"
+
     client.delete(
         f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
     )
 
 
-def test_create_listener_normalization_preserves_user_defined_ports(client, admin_auth_header):
+def test_create_listener_normalization_preserves_user_defined_ports(
+    client, admin_auth_header
+):
     base_listener = get_base_listener()
     base_listener["name"] = "temp123"
     base_listener["options"]["Host"] = "http://localhost:443"
-    base_listener["options"]["Port"] = '1234'
+    base_listener["options"]["Port"] = "1234"
 
     response = client.post(
         "/api/v2/listeners/", headers=admin_auth_header, json=base_listener
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["options"]["Host"] == "http://localhost:443"
-    assert response.json()["options"]["Port"] == '1234'
-    
+    assert response.json()["options"]["Port"] == "1234"
+
     client.delete(
         f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
     )
 
 
-def test_create_listener_normalization_sets_host_port_as_bind_port(client, admin_auth_header):
+def test_create_listener_normalization_sets_host_port_as_bind_port(
+    client, admin_auth_header
+):
     base_listener = get_base_listener()
     base_listener["name"] = "temp123"
     base_listener["options"]["Host"] = "http://localhost:443"
@@ -187,8 +193,8 @@ def test_create_listener_normalization_sets_host_port_as_bind_port(client, admin
     )
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["options"]["Host"] == "http://localhost:443"
-    assert response.json()["options"]["Port"] == '443'
-    
+    assert response.json()["options"]["Port"] == "443"
+
     client.delete(
         f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
     )

--- a/empire/test/test_listener_api.py
+++ b/empire/test/test_listener_api.py
@@ -122,6 +122,78 @@ def test_create_listener_template_not_found(client, admin_auth_header):
     assert response.json()["detail"] == "Listener Template qwerty not found"
 
 
+def test_create_listener_normalization_adds_protocol_and_default_port(client, admin_auth_header):
+    base_listener = get_base_listener()
+    base_listener["name"] = "temp123"
+    base_listener["options"]["Host"] = "localhost"
+    base_listener["options"]["Port"] = None
+
+    response = client.post(
+        "/api/v2/listeners/", headers=admin_auth_header, json=base_listener
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["options"]["Host"] == "http://localhost:80"
+    assert response.json()["options"]["Port"] == '80'
+    
+    client.delete(
+        f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
+    )
+
+
+def test_create_listener_normalization_adds_port_to_host(client, admin_auth_header):
+    base_listener = get_base_listener()
+    base_listener["name"] = "temp123"
+    base_listener["options"]["Host"] = "http://localhost"
+    base_listener["options"]["Port"] = '1234'
+
+    response = client.post(
+        "/api/v2/listeners/", headers=admin_auth_header, json=base_listener
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["options"]["Host"] == "http://localhost:1234"
+    assert response.json()["options"]["Port"] == '1234'
+    
+    client.delete(
+        f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
+    )
+
+
+def test_create_listener_normalization_preserves_user_defined_ports(client, admin_auth_header):
+    base_listener = get_base_listener()
+    base_listener["name"] = "temp123"
+    base_listener["options"]["Host"] = "http://localhost:443"
+    base_listener["options"]["Port"] = '1234'
+
+    response = client.post(
+        "/api/v2/listeners/", headers=admin_auth_header, json=base_listener
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["options"]["Host"] == "http://localhost:443"
+    assert response.json()["options"]["Port"] == '1234'
+    
+    client.delete(
+        f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
+    )
+
+
+def test_create_listener_normalization_sets_host_port_as_bind_port(client, admin_auth_header):
+    base_listener = get_base_listener()
+    base_listener["name"] = "temp123"
+    base_listener["options"]["Host"] = "http://localhost:443"
+    base_listener["options"]["Port"] = None
+
+    response = client.post(
+        "/api/v2/listeners/", headers=admin_auth_header, json=base_listener
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["options"]["Host"] == "http://localhost:443"
+    assert response.json()["options"]["Port"] == '443'
+    
+    client.delete(
+        f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
+    )
+
+
 def test_create_listener(client, admin_auth_header):
     base_listener = get_base_listener()
     base_listener["name"] = "temp123"


### PR DESCRIPTION
## Describe your changes

I modified the normalization function for Host and Port values when creating or updating a new listener.

The new approach uses a regexp to match the various parts of the host value, allowing for protocol and port to be optional, it then performs the same normalization of protocol and ports as it was doing before.

The Host value normalization can have two outcomes:
1) port was parsed from host value, then the host value will be normalized to "protocol://host:port"
2) port was not found in host value, then the host value will be normalized to "protocol://host". In this case, if the Port value is not set, the Host normalization will set the Port value to the default port.

Port normalization happens after host normalization. So during Port normalization the code splits the Host value using ':' as delimiter, if it gets 3 values leaves them untouched, otherwise appends the port value to the Host value.

## Issue ticket number and link (if there is one)

792 https://github.com/BC-SECURITY/Empire/issues/792

## Checklist before requesting a review
- [ X] I have performed a self-review of my code
- [ X] If it is a core feature, I have added thorough tests.
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have updated the documentation in `docs/` (if applicable) 
