### PR TITLE
Fix bof nanodump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fixed stop-job handlers in PowerShell and Python agents crashing when the target job doesn't exist
+-   Fixed bof nanodump module not running
 
 ## [6.4.1] - 2026-02-15
 -   Fixed the `docs/quickstart/installation/README.md` file to specify a previously missing reference to Ubuntu

--- a/empire/server/modules/bof/credentials/nanodump.py
+++ b/empire/server/modules/bof/credentials/nanodump.py
@@ -16,7 +16,6 @@ class Module:
             "ProcessID": params.get("pid") if params.get("pid") else "0",
             "DumpPath": params.get("write", "find_me.dmp"),
             "WriteFile": "1" if params.get("write") else "0",
-            "Chunksize": params.get("chunksize") if params.get("chunksize") else "0",
             "ValidSignature": "1" if params.get("valid").lower() == "true" else "0",
             "Fork": "1" if params.get("fork").lower() == "true" else "0",
             "Snapshot": "1" if params.get("snapshot").lower() == "true" else "0",
@@ -43,10 +42,6 @@ class Module:
             "SilentProcessExitBinary": params.get("silent-process-exit", ""),
             "Shtinkering": "1" if params.get("shtinkering").lower() == "true" else "0",
         }
-
-        import debugpy
-        # debugpy.wait_for_client()
-        # breakpoint()
 
         return main_menu.modulesv2.generate_script_bof(
             module=module,

--- a/empire/server/modules/bof/credentials/nanodump.py
+++ b/empire/server/modules/bof/credentials/nanodump.py
@@ -17,32 +17,36 @@ class Module:
             "DumpPath": params.get("write", "find_me.dmp"),
             "WriteFile": "1" if params.get("write") else "0",
             "Chunksize": params.get("chunksize") if params.get("chunksize") else "0",
-            "ValidSignature": "1" if params.get("valid") == "true" else "0",
-            "Fork": "1" if params.get("fork") == "true" else "0",
-            "Snapshot": "1" if params.get("snapshot") == "true" else "0",
-            "DuplicateHandle": "1" if params.get("duplicate") == "true" else "0",
-            "ElevateHandle": "1" if params.get("elevate-handle") == "true" else "0",
+            "ValidSignature": "1" if params.get("valid").lower() == "true" else "0",
+            "Fork": "1" if params.get("fork").lower() == "true" else "0",
+            "Snapshot": "1" if params.get("snapshot").lower() == "true" else "0",
+            "DuplicateHandle": "1" if params.get("duplicate").lower() == "true" else "0",
+            "ElevateHandle": "1" if params.get("elevate-handle").lower() == "true" else "0",
             "DuplicateElevate": (
-                "1" if params.get("duplicate-elevate") == "true" else "0"
+                "1" if params.get("duplicate-elevate").lower() == "true" else "0"
             ),
-            "GetPID": "1" if params.get("getpid") == "true" else "0",
+            "GetPID": "1" if params.get("getpid").lower() == "true" else "0",
             "SecLogonLeakLocal": (
-                "1" if params.get("seclogon-leak-local") == "true" else "0"
+                "1" if params.get("seclogon-leak-local").lower() == "true" else "0"
             ),
             "SecLogonLeakRemote": (
-                "1" if params.get("seclogon-leak-remote") == "true" else "0"
+                "1" if params.get("seclogon-leak-remote").lower() == "true" else "0"
             ),
             "SecLogonLeakRemoteBinary": (
-                "0" if params.get("seclogon-leak-remote") == "true" else ""
+                "0" if params.get("seclogon-leak-remote").lower() == "true" else ""
             ),
             "SecLogonDuplicate": (
-                "1" if params.get("seclogon-duplicate") == "true" else "0"
+                "1" if params.get("seclogon-duplicate").lower() == "true" else "0"
             ),
-            "SpoofCallstack": "1" if params.get("spoof-callstack") == "true" else "0",
-            "SilentProcessExit": "1" if params.get("silent-process-exit") else "0",
+            "SpoofCallstack": "1" if params.get("spoof-callstack").lower() == "true" else "0",
+            "SilentProcessExit": "1" if params.get("silent-process-exit").lower() else "0",
             "SilentProcessExitBinary": params.get("silent-process-exit", ""),
-            "Shtinkering": "1" if params.get("shtinkering") == "true" else "0",
+            "Shtinkering": "1" if params.get("shtinkering").lower() == "true" else "0",
         }
+
+        import debugpy
+        # debugpy.wait_for_client()
+        # breakpoint()
 
         return main_menu.modulesv2.generate_script_bof(
             module=module,

--- a/empire/server/modules/bof/credentials/nanodump.yaml
+++ b/empire/server/modules/bof/credentials/nanodump.yaml
@@ -7,8 +7,8 @@ description: Beacon Object File (BOF) that creates a minidump of the LSASS proce
   using various evasion techniques to bypass security monitoring. Supports multiple
   dumping methods including handle duplication, process forking, snapshot creation,
   and seclogon handle leaking. Can generate both valid and invalid signature dumps,
-  with options for chunked writing and various privilege escalation techniques to
-  access LSASS memory while avoiding detection.
+  with various privilege escalation techniques to access LSASS memory while avoiding
+  detection.
 software: ''
 tactics: [TA0006]
 techniques: [T1003.001]
@@ -138,7 +138,7 @@ bof:
   x86: bof/nanodump/nanodump.x86.o
   x64: bof/nanodump/nanodump.x64.o
   entry_point: ''
-  format_string: iziiiiiiiiiiiziiizi
+  format_string: iziiiiiiiiiiziiizi
 script_path: ''
 script_end: ''
 advanced:


### PR DESCRIPTION
## Describe your changes
I've noticed the nanodump bof is not working. Upon further investigation, the cause appears to be the addition of the chunksize parameter in [this commit](https://github.com/BC-SECURITY/Empire/commit/698cf4bc2214dca93316a531f9639c388f53c41a). It was added to nanodump [here](https://github.com/fortra/nanodump/commit/cdb4d9f85434a53c227fedc7af1abacbd1aba424), and I assume the `nanodump.x64.o` was not updated in the Empire repo. That could be another potential solution to the problem instead of the commits proposed in this PR.

Additionally, I have found the module doesn't work if the `SpoofCallstack` parameter is `True`, but I haven't managed to find the bug. The standalone `nanodump` executable doesn't have this issue.

I have performed manual tests and the module is now working if `SpoofCallstack` is not `True`.

## Issue ticket number and link (if there is one)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have updated the documentation in `docs/` (if applicable)
