### PR TITLE
Allow different host port and listener port

### DIFF
--- a/empire/server/common/malleable/implementation.py
+++ b/empire/server/common/malleable/implementation.py
@@ -396,8 +396,7 @@ class Stager(Transaction):
         self.server.output = Container()
         self.client.verb = "GET"
 
-        # Having a missing http-stager and '/' in http-get or http-post throws an error
-        # Use a fixed default uri to avoid collision while remaining consistent across restarts
+    def add_default_uri(self):
         if not self.client.uris:
             self.client.uris = ["/init/"]
 

--- a/empire/server/common/malleable/implementation.py
+++ b/empire/server/common/malleable/implementation.py
@@ -395,8 +395,7 @@ class Stager(Transaction):
         self.server.output = Container()
         self.client.verb = "GET"
 
-        # Having a missing http-stager and '/' in http-get or http-post throws an error
-        # Use a fixed default uri to avoid collision while remaining consistent across restarts
+    def add_default_uri(self):
         if not self.client.uris:
             self.client.uris = ["/init/"]
 

--- a/empire/server/common/malleable/profile.py
+++ b/empire/server/common/malleable/profile.py
@@ -128,6 +128,7 @@ class Profile(MalleableObject):
             data: pyparsing data
         """
         if data:
+            http_stager_found = False
             for group in [d for d in data if d]:
                 for i in range(0, len(group), 2):
                     item = group[i]
@@ -143,7 +144,9 @@ class Profile(MalleableObject):
                             self.post._parse(arg)
                         elif item.lower() == "http-stager":
                             self.stager._parse(arg)
-
+                            http_stager_found = True
+            if not http_stager_found:
+                self.stager.add_default_uri()
     @property
     def useragent(self):
         """Get the profile useragent.

--- a/empire/server/common/malleable/profile.py
+++ b/empire/server/common/malleable/profile.py
@@ -127,6 +127,7 @@ class Profile(MalleableObject):
             data: pyparsing data
         """
         if data:
+            http_stager_found = False
             for group in [d for d in data if d]:
                 for i in range(0, len(group), 2):
                     item = group[i]
@@ -142,7 +143,9 @@ class Profile(MalleableObject):
                             self.post._parse(arg)
                         elif item.lower() == "http-stager":
                             self.stager._parse(arg)
-
+                            http_stager_found = True
+            if not http_stager_found:
+                self.stager.add_default_uri()
     @property
     def useragent(self):
         """Get the profile useragent.

--- a/empire/server/core/listener_service.py
+++ b/empire/server/core/listener_service.py
@@ -225,18 +225,17 @@ class ListenerService:
                 else:
                     protocol = "http"
             if port:
-                return None, "Port cannot be provided in a host name"
-            host_address = f"{protocol}://{host}"
+                if (port == "443" and protocol == "https") or (
+                    port == "80" and protocol == "http"
+                ):
+                    host_address = f"{protocol}://{host}/"
+                else:
+                    host_address = f"{protocol}://{host}:{port}/"
+            else:
+                host_address = f"{protocol}://{host}/"
         except AttributeError:
             return None, "Hostname error in parsing"
 
-        port = listener_options["Port"]["Value"]
-        if (protocol == "https" and port == "443") or (
-            protocol == "http" and port == "80"
-        ):
-            host_address += "/"
-            return host_address, None
-        host_address += f":{port}/"
         return host_address, None
 
     def _validate_listener_options(

--- a/empire/server/core/listener_service.py
+++ b/empire/server/core/listener_service.py
@@ -224,15 +224,15 @@ class ListenerService:
                     protocol = "https"
                 else:
                     protocol = "http"
-            if port:
-                if (port == "443" and protocol == "https") or (
-                    port == "80" and protocol == "http"
-                ):
-                    host_address = f"{protocol}://{host}/"
-                else:
-                    host_address = f"{protocol}://{host}:{port}/"
-            else:
+            if not port:
+                port = listener_options["Port"]["Value"]
+
+            if (port == "443" and protocol == "https") or (
+                port == "80" and protocol == "http"
+            ):
                 host_address = f"{protocol}://{host}/"
+            else:
+                host_address = f"{protocol}://{host}:{port}/"
         except AttributeError:
             return None, "Hostname error in parsing"
 

--- a/empire/server/core/listener_service.py
+++ b/empire/server/core/listener_service.py
@@ -243,15 +243,15 @@ class ListenerService:
                     protocol = "https"
                 else:
                     protocol = "http"
-            if port:
-                if (port == "443" and protocol == "https") or (
-                    port == "80" and protocol == "http"
-                ):
-                    host_address = f"{protocol}://{host}/"
-                else:
-                    host_address = f"{protocol}://{host}:{port}/"
-            else:
+            if not port:
+                port = listener_options["Port"]["Value"]
+
+            if (port == "443" and protocol == "https") or (
+                port == "80" and protocol == "http"
+            ):
                 host_address = f"{protocol}://{host}/"
+            else:
+                host_address = f"{protocol}://{host}:{port}/"
         except AttributeError:
             return None, "Hostname error in parsing"
 

--- a/empire/server/core/listener_service.py
+++ b/empire/server/core/listener_service.py
@@ -244,18 +244,17 @@ class ListenerService:
                 else:
                     protocol = "http"
             if port:
-                return None, "Port cannot be provided in a host name"
-            host_address = f"{protocol}://{host}"
+                if (port == "443" and protocol == "https") or (
+                    port == "80" and protocol == "http"
+                ):
+                    host_address = f"{protocol}://{host}/"
+                else:
+                    host_address = f"{protocol}://{host}:{port}/"
+            else:
+                host_address = f"{protocol}://{host}/"
         except AttributeError:
             return None, "Hostname error in parsing"
 
-        port = listener_options["Port"]["Value"]
-        if (protocol == "https" and port == "443") or (
-            protocol == "http" and port == "80"
-        ):
-            host_address += "/"
-            return host_address, None
-        host_address += f":{port}/"
         return host_address, None
 
     def _validate_listener_options(

--- a/empire/server/listeners/http_malleable.py
+++ b/empire/server/listeners/http_malleable.py
@@ -273,6 +273,12 @@ class Listener:
 
         return True, None
 
+    def get_malleable_port(self, listenerOptions):
+        try:
+            return listenerOptions["Host"]["Value"].split(":")[2]
+        except IndexError:
+            return listenerOptions["Port"]["Value"]
+
     def generate_launcher(
         self,
         encode=True,
@@ -300,7 +306,7 @@ class Listener:
         # extract the set options for this instantiated listener
         listenerOptions = active_listener.options
 
-        port = listenerOptions["Port"]["Value"]
+        port = self.get_malleable_port(listenerOptions)
         host = listenerOptions["Host"]["Value"]
         launcher = listenerOptions["Launcher"]["Value"]
         stagingKey = listenerOptions["StagingKey"]["Value"]
@@ -532,7 +538,7 @@ class Listener:
 
             # ==== BUILD REQUEST ====
             launcherBase += "vreq=type('vreq',(urllib.request.Request,object),{'get_method':lambda self:self.verb if (hasattr(self,'verb') and self.verb) else urllib.request.Request.get_method(self)})\n"
-            launcherBase += f"req=vreq('{profile.stager.client.url}', {profile.stager.client.body})\n"
+            launcherBase += f"req=vreq(server+'{profile.stager.client.path + profile.stager.client.query}', {profile.stager.client.body})\n"
             launcherBase += "req.verb='" + profile.stager.client.verb + "'\n"
 
             # ==== ADD HEADERS ====
@@ -602,8 +608,8 @@ class Listener:
             return None
 
         # extract the set options for this instantiated listener
-        port = listenerOptions["Port"]["Value"]
         host = listenerOptions["Host"]["Value"]
+        port = self.get_malleable_port(listenerOptions)
         stagingKey = listenerOptions["StagingKey"]["Value"]
         workingHours = listenerOptions["WorkingHours"]["Value"]
         killDate = listenerOptions["KillDate"]["Value"]

--- a/empire/test/test_listener_api.py
+++ b/empire/test/test_listener_api.py
@@ -173,8 +173,12 @@ def test_create_listener_normalization_preserves_user_defined_ports(
     response = client.post(
         "/api/v2/listeners/", headers=admin_auth_header, json=base_listener
     )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "Port cannot be provided in a host name"
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["host_address"] == "http://localhost:443/"
+
+    client.delete(
+        f"/api/v2/listeners/{response.json()['id']}", headers=admin_auth_header
+    )
 
 
 def test_create_listener_normalization_sets_host_port_as_bind_port(

--- a/empire/test/test_listener_generate_launcher.py
+++ b/empire/test/test_listener_generate_launcher.py
@@ -335,7 +335,7 @@ def _expected_http_malleable_python_launcher():
         o = urllib.request.build_opener(proxy)
         urllib.request.install_opener(o)
         vreq=type('vreq',(urllib.request.Request,object),{'get_method':lambda self:self.verb if (hasattr(self,'verb') and self.verb) else urllib.request.Request.get_method(self)})
-        req=vreq('http://localhost:80/init/', )
+        req=vreq(server+'/init/', )
         req.verb='GET'
         req.add_header('User-Agent','Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko')
         req.add_header('Cookie','session=cm91dGluZyBwYWNrZXQ%3D')


### PR DESCRIPTION
## Describe your changes
This merge request addresses the possibility to have a different host port and bind port (scenario when Empire runs behind a reverse proxy).

The merge requests maintains the old behavior of forcing the bind port into the host if the host port is not specified.

Additionally, while working on this issue I had already noticed another issue with the default uris for malleable profile when missing the stager block. My solution is a bit different than the one currently in main, adding the default uri only when the stager block is not found. During my tests, the original approach ended up creating this additional uri even when the stager block was present (and then it could be randomly selected when generating the launchers).

## Issue ticket number and link (if there is one)
https://github.com/BC-SECURITY/Empire/issues/808

## Checklist before requesting a review
- [X ] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
- [-] I have added an entry to `CHANGELOG.md`
- [X] I have updated the documentation in `docs/` (if applicable)
