### PR TITLE
Fix non-existing stop_job to stop_task and job_list to task_list

### DIFF
--- a/empire/server/data/agent/agent.py
+++ b/empire/server/data/agent/agent.py
@@ -1005,10 +1005,10 @@ class MainAgent:
                 self.directory_list(data, result_id)
 
             elif packet_type == 50:
-                self.job_list(result_id)
+                self.task_list(result_id)
 
             elif packet_type == 51:
-                self.stop_job(data, result_id)
+                self.stop_task(data, result_id)
 
             elif packet_type == 60:
                 self.packet_handler.send_message(


### PR DESCRIPTION
## Describe your changes

Fixes non-existing `stop_job` and `job_list` to `stop_task` and `task_list` respectively.

## Issue ticket number and link (if there is one)

#825 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have updated the documentation in `docs/` (if applicable)
